### PR TITLE
feat: detect app feedback in chat and create GitHub issues

### DIFF
--- a/src/lib/github-tools.ts
+++ b/src/lib/github-tools.ts
@@ -1,0 +1,79 @@
+/**
+ * GitHub integration for creating feedback issues
+ */
+
+interface CreateIssueResult {
+  success: boolean;
+  issueNumber?: number;
+  message: string;
+}
+
+type FeedbackType = 'bug' | 'feature' | 'improvement' | 'question';
+
+/**
+ * Create a GitHub issue for app feedback
+ */
+export async function createFeedbackIssue(
+  userId: string,
+  title: string,
+  description: string,
+  feedbackType: FeedbackType
+): Promise<CreateIssueResult> {
+  const token = process.env.GITHUB_TOKEN;
+  const repo = process.env.GITHUB_REPO || 'vinzenzweber/habits';
+
+  if (!token) {
+    console.error('GITHUB_TOKEN not configured');
+    return { success: false, message: 'GitHub integration not configured' };
+  }
+
+  // Map feedback type to GitHub labels
+  const labelMap: Record<FeedbackType, string[]> = {
+    'bug': ['bug', 'user-feedback'],
+    'feature': ['enhancement', 'user-feedback'],
+    'improvement': ['enhancement', 'user-feedback'],
+    'question': ['question', 'user-feedback']
+  };
+
+  const issueBody = `## User Feedback
+
+${description}
+
+---
+*Submitted via in-app chat*
+*User ID: ${userId}*
+*Date: ${new Date().toISOString()}*`;
+
+  try {
+    const response = await fetch(`https://api.github.com/repos/${repo}/issues`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Accept': 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        title: `[User Feedback] ${title}`,
+        body: issueBody,
+        labels: labelMap[feedbackType]
+      })
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      console.error('GitHub API error:', error);
+      return { success: false, message: 'Failed to create issue' };
+    }
+
+    const data = await response.json();
+    return {
+      success: true,
+      issueNumber: data.number,
+      message: 'Feedback recorded'
+    };
+  } catch (error) {
+    console.error('GitHub issue creation error:', error);
+    return { success: false, message: 'Failed to create issue' };
+  }
+}

--- a/src/lib/memory-tools.ts
+++ b/src/lib/memory-tools.ts
@@ -9,6 +9,7 @@ export const MEMORY_CATEGORIES = [
   'experience',   // Training experience level, sports background
   'schedule',     // Available training days/times, constraints
   'measurements', // Body measurements, weight, PRs
+  'feedback',     // App feedback and feature requests
 ] as const;
 
 export type MemoryCategory = typeof MEMORY_CATEGORIES[number];


### PR DESCRIPTION
## Summary
- Add automatic detection of app/product feedback in AI chat
- AI distinguishes between app feedback ("timer keeps resetting") vs fitness feedback ("workout was too hard")
- Asks 1-2 clarifying questions before recording feedback
- Creates GitHub issue silently via new `create_feedback_issue` tool
- Saves feedback to user memory with new 'feedback' category

## Changes
- **New:** `src/lib/github-tools.ts` - GitHub API integration for issue creation
- **Modified:** `src/lib/memory-tools.ts` - Added 'feedback' to MEMORY_CATEGORIES
- **Modified:** `src/app/api/chat/route.ts` - Added tool, handler, and prompt instructions

## Test plan
- [x] Build passes with no TypeScript errors
- [x] Tested chat feedback flow locally with Playwright
- [x] AI correctly detects app feedback and asks clarifying questions
- [x] AI saves feedback to memory successfully
- [x] Graceful failure when GITHUB_TOKEN not configured (memory still saved)
- [ ] Test with GITHUB_TOKEN configured to verify issue creation

## Environment Variables (optional)
```bash
GITHUB_TOKEN=ghp_...
GITHUB_REPO=vinzenzweber/habits
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)