### PR TITLE
feat: improve chat UX with auto-focus and live workout updates

### DIFF
--- a/src/components/ChatModal.tsx
+++ b/src/components/ChatModal.tsx
@@ -95,6 +95,7 @@ export function ChatModal({
   useEffect(() => {
     if (!isOpen) {
       hasAutoSentRef.current = false;
+      workoutUpdatedRef.current = false;
       setShowRatingButtons(false);
       setRatingSubmitted(false);
       setAwaitingRating(false);
@@ -103,12 +104,18 @@ export function ChatModal({
 
   // Auto-focus textarea when modal opens
   useEffect(() => {
-    if (isOpen && textareaRef.current) {
-      // Small delay to ensure modal is rendered
-      setTimeout(() => {
-        textareaRef.current?.focus();
-      }, 100);
+    if (!isOpen || !textareaRef.current) {
+      return;
     }
+
+    // Small delay to ensure modal is rendered
+    const timeoutId = setTimeout(() => {
+      textareaRef.current?.focus();
+    }, 100);
+
+    return () => {
+      clearTimeout(timeoutId);
+    };
   }, [isOpen]);
 
   // Show rating buttons after AI responds to workout completion


### PR DESCRIPTION
## Summary
- Auto-focus message input when chat modal opens so users can start typing immediately
- Auto-refresh page when AI updates workout via tool call (e.g., exercise replacements)
- Track workout updates during streaming and trigger `router.refresh()` on completion

## Test plan
- [ ] Open chat modal and verify input is focused automatically
- [ ] Request a workout modification (e.g., "change exercise X to Y")
- [ ] Verify the page updates automatically after AI confirms the change
- [ ] Verify changes appear in the workout list without manual refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)