### PR TITLE
feat: improve voice input UX and filter feedback from user context

### DIFF
--- a/src/lib/memory-tools.ts
+++ b/src/lib/memory-tools.ts
@@ -115,15 +115,19 @@ export async function deleteMemory(
 
 /**
  * Format memories as context string for the AI
+ * Excludes internal categories like 'feedback' which aren't user preferences
  */
 export function formatMemoriesAsContext(memories: UserMemory[]): string {
-  if (memories.length === 0) {
+  // Filter out non-preference categories
+  const preferenceMemories = memories.filter(m => m.category !== 'feedback');
+
+  if (preferenceMemories.length === 0) {
     return "No user information stored yet.";
   }
 
   const grouped: Record<string, string[]> = {};
 
-  for (const mem of memories) {
+  for (const mem of preferenceMemories) {
     if (!grouped[mem.category]) {
       grouped[mem.category] = [];
     }


### PR DESCRIPTION
## Summary
- Make mic button same size as send button for visual consistency
- Auto-send message immediately after voice transcription completes (no extra tap needed)
- Filter out 'feedback' category from user profile context in system prompts

## Test plan
- [ ] Open chat modal and verify mic button is same height as Send button
- [ ] Use voice input and verify message sends automatically after transcription
- [ ] Verify user preferences still appear in chat context (equipment, goals, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)