### PR TITLE
feat: add recipes database migration and TypeScript data layer

### DIFF
--- a/scripts/migrations/011_recipes.sql
+++ b/scripts/migrations/011_recipes.sql
@@ -1,0 +1,37 @@
+-- Migration: 011_recipes
+-- Description: Add recipes feature with versioning and JSONB storage
+-- Created: 2026-01-15
+
+CREATE TABLE recipes (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  slug VARCHAR(200) NOT NULL,
+  version INTEGER NOT NULL DEFAULT 1,
+  title TEXT NOT NULL,
+  description TEXT,
+  locale VARCHAR(10) DEFAULT 'de-DE',
+  tags JSONB DEFAULT '[]',
+  recipe_json JSONB NOT NULL,
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(user_id, slug, version)
+);
+
+-- Index for querying user's active recipes
+CREATE INDEX idx_recipes_user_active ON recipes(user_id, is_active);
+
+-- Index for querying by slug
+CREATE INDEX idx_recipes_user_slug ON recipes(user_id, slug);
+
+-- GIN index for tag-based filtering
+CREATE INDEX idx_recipes_tags ON recipes USING GIN(tags);
+
+-- Full-text search index (German language)
+CREATE INDEX idx_recipes_search ON recipes USING GIN(
+  to_tsvector('german', title || ' ' || COALESCE(description, ''))
+);
+
+-- Unique partial index for active recipes (only one active version per slug)
+CREATE UNIQUE INDEX idx_recipes_user_slug_active_unique
+ON recipes(user_id, slug) WHERE is_active = true;

--- a/src/app/api/recipes/[slug]/route.ts
+++ b/src/app/api/recipes/[slug]/route.ts
@@ -1,0 +1,86 @@
+import { auth } from "@/lib/auth";
+import { getRecipeBySlug, updateRecipe, deleteRecipe } from "@/lib/recipes";
+import { UpdateRecipeInput } from "@/lib/recipe-types";
+
+export const runtime = "nodejs";
+
+type RouteParams = { params: Promise<{ slug: string }> };
+
+/**
+ * GET /api/recipes/[slug]
+ * Get a single recipe by slug
+ */
+export async function GET(request: Request, { params }: RouteParams) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { slug } = await params;
+    const recipe = await getRecipeBySlug(slug);
+
+    if (!recipe) {
+      return Response.json({ error: "Recipe not found" }, { status: 404 });
+    }
+
+    return Response.json({ recipe });
+  } catch (error) {
+    console.error("Error fetching recipe:", error);
+    return Response.json(
+      { error: "Failed to fetch recipe" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * PATCH /api/recipes/[slug]
+ * Update a recipe
+ */
+export async function PATCH(request: Request, { params }: RouteParams) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { slug } = await params;
+    const body = await request.json() as UpdateRecipeInput;
+
+    const recipe = await updateRecipe(slug, body);
+    return Response.json({ recipe });
+  } catch (error) {
+    console.error("Error updating recipe:", error);
+    if (error instanceof Error && error.message === "Recipe not found") {
+      return Response.json({ error: "Recipe not found" }, { status: 404 });
+    }
+    return Response.json(
+      { error: "Failed to update recipe" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * DELETE /api/recipes/[slug]
+ * Delete a recipe (soft delete)
+ */
+export async function DELETE(request: Request, { params }: RouteParams) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { slug } = await params;
+    await deleteRecipe(slug);
+    return Response.json({ success: true });
+  } catch (error) {
+    console.error("Error deleting recipe:", error);
+    return Response.json(
+      { error: "Failed to delete recipe" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/recipes/route.ts
+++ b/src/app/api/recipes/route.ts
@@ -1,0 +1,58 @@
+import { auth } from "@/lib/auth";
+import { getUserRecipes, createRecipe } from "@/lib/recipes";
+import { CreateRecipeInput } from "@/lib/recipe-types";
+
+export const runtime = "nodejs";
+
+/**
+ * GET /api/recipes
+ * Get all recipes for the current user
+ */
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const recipes = await getUserRecipes();
+    return Response.json({ recipes });
+  } catch (error) {
+    console.error("Error fetching recipes:", error);
+    return Response.json(
+      { error: "Failed to fetch recipes" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * POST /api/recipes
+ * Create a new recipe
+ */
+export async function POST(request: Request) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const body = await request.json() as CreateRecipeInput;
+
+    if (!body.title || !body.recipeJson) {
+      return Response.json(
+        { error: "Missing required fields: title and recipeJson" },
+        { status: 400 }
+      );
+    }
+
+    const recipe = await createRecipe(body);
+    return Response.json({ recipe }, { status: 201 });
+  } catch (error) {
+    console.error("Error creating recipe:", error);
+    return Response.json(
+      { error: "Failed to create recipe" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/recipe-types.ts
+++ b/src/lib/recipe-types.ts
@@ -1,0 +1,114 @@
+/**
+ * Recipe feature types
+ * Follows workout pattern with JSONB storage and versioning
+ */
+
+export interface Ingredient {
+  id: string;
+  name: string;
+  amount: number;
+  unit: string;
+  notes?: string;
+  isOptional?: boolean;
+}
+
+export interface InstructionStep {
+  id: string;
+  step: number;
+  text: string;
+  durationMinutes?: number;
+  tip?: string;
+}
+
+export interface NutritionInfo {
+  calories?: number;
+  protein?: number;
+  carbs?: number;
+  fat?: number;
+  fiber?: number;
+  sodium?: number;
+}
+
+export type RecipeSourceType = "manual" | "imported" | "shared" | "ai_generated";
+
+export interface RecipeJson {
+  ingredients: Ingredient[];
+  instructions: InstructionStep[];
+  nutrition?: NutritionInfo;
+  notes?: string;
+  imageUrl?: string;
+  // Metadata fields stored in JSONB
+  prepTimeMinutes?: number;
+  cookTimeMinutes?: number;
+  servings?: number;
+  sourceType?: RecipeSourceType;
+  sourceUrl?: string;
+  isFavorite?: boolean;
+  rating?: number;
+}
+
+export interface Recipe {
+  id: number;
+  userId: number;
+  slug: string;
+  version: number;
+  title: string;
+  description: string | null;
+  locale: string;
+  tags: string[];
+  recipeJson: RecipeJson;
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+// Database row type (snake_case)
+export interface RecipeRow {
+  id: number;
+  user_id: number;
+  slug: string;
+  version: number;
+  title: string;
+  description: string | null;
+  locale: string;
+  tags: string[];
+  recipe_json: RecipeJson;
+  is_active: boolean;
+  created_at: Date;
+  updated_at: Date;
+}
+
+// Convert database row to TypeScript type
+export function rowToRecipe(row: RecipeRow): Recipe {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    slug: row.slug,
+    version: row.version,
+    title: row.title,
+    description: row.description,
+    locale: row.locale,
+    tags: row.tags,
+    recipeJson: row.recipe_json,
+    isActive: row.is_active,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+// Input types for creating/updating
+export interface CreateRecipeInput {
+  title: string;
+  description?: string;
+  locale?: string;
+  tags?: string[];
+  recipeJson: RecipeJson;
+}
+
+export interface UpdateRecipeInput {
+  title?: string;
+  description?: string;
+  locale?: string;
+  tags?: string[];
+  recipeJson?: RecipeJson;
+}

--- a/src/lib/recipes.ts
+++ b/src/lib/recipes.ts
@@ -1,0 +1,285 @@
+/**
+ * Recipe data access layer
+ * Follows workout pattern with versioning and user scoping
+ */
+
+import { query, transaction } from "./db";
+import { auth } from "./auth";
+import {
+  Recipe,
+  RecipeRow,
+  CreateRecipeInput,
+  UpdateRecipeInput,
+  rowToRecipe,
+} from "./recipe-types";
+
+/**
+ * Generate a URL-friendly slug from a recipe title
+ */
+export function generateSlug(title: string): string {
+  return title
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "") // Remove diacritics (ä→a, ü→u, etc.)
+    .replace(/[^a-z0-9]+/g, "-") // Replace non-alphanumeric with hyphens
+    .replace(/^-+|-+$/g, "") // Trim leading/trailing hyphens
+    .substring(0, 200); // Max length
+}
+
+/**
+ * Check if a slug exists for a user
+ */
+async function slugExists(userId: number, slug: string): Promise<boolean> {
+  const result = await query<{ count: string }>(
+    `SELECT COUNT(*) as count FROM recipes WHERE user_id = $1 AND slug = $2`,
+    [userId, slug]
+  );
+  return parseInt(result.rows[0].count, 10) > 0;
+}
+
+/**
+ * Get a unique slug for a recipe, appending numbers if needed
+ */
+export async function getUniqueSlug(
+  userId: number,
+  title: string
+): Promise<string> {
+  const baseSlug = generateSlug(title);
+  let slug = baseSlug;
+  let counter = 2;
+
+  while (await slugExists(userId, slug)) {
+    slug = `${baseSlug}-${counter}`;
+    counter++;
+  }
+
+  return slug;
+}
+
+/**
+ * Get all active recipes for the current user
+ */
+export async function getUserRecipes(): Promise<Recipe[]> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    throw new Error("Not authenticated");
+  }
+  const userId = parseInt(session.user.id, 10);
+
+  const result = await query<RecipeRow>(
+    `SELECT * FROM recipes
+     WHERE user_id = $1 AND is_active = true
+     ORDER BY updated_at DESC`,
+    [userId]
+  );
+
+  return result.rows.map(rowToRecipe);
+}
+
+/**
+ * Get a single recipe by slug
+ */
+export async function getRecipeBySlug(slug: string): Promise<Recipe | null> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    throw new Error("Not authenticated");
+  }
+  const userId = parseInt(session.user.id, 10);
+
+  const result = await query<RecipeRow>(
+    `SELECT * FROM recipes
+     WHERE user_id = $1 AND slug = $2 AND is_active = true
+     ORDER BY version DESC LIMIT 1`,
+    [userId, slug]
+  );
+
+  if (result.rows.length === 0) {
+    return null;
+  }
+
+  return rowToRecipe(result.rows[0]);
+}
+
+/**
+ * Search recipes by tags
+ */
+export async function getRecipesByTags(tags: string[]): Promise<Recipe[]> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    throw new Error("Not authenticated");
+  }
+  const userId = parseInt(session.user.id, 10);
+
+  const result = await query<RecipeRow>(
+    `SELECT * FROM recipes
+     WHERE user_id = $1 AND is_active = true AND tags ?| $2
+     ORDER BY updated_at DESC`,
+    [userId, tags]
+  );
+
+  return result.rows.map(rowToRecipe);
+}
+
+/**
+ * Full-text search recipes
+ */
+export async function searchRecipes(searchTerm: string): Promise<Recipe[]> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    throw new Error("Not authenticated");
+  }
+  const userId = parseInt(session.user.id, 10);
+
+  const result = await query<RecipeRow>(
+    `SELECT * FROM recipes
+     WHERE user_id = $1 AND is_active = true
+     AND to_tsvector('german', title || ' ' || COALESCE(description, '')) @@ plainto_tsquery('german', $2)
+     ORDER BY updated_at DESC`,
+    [userId, searchTerm]
+  );
+
+  return result.rows.map(rowToRecipe);
+}
+
+/**
+ * Create a new recipe
+ */
+export async function createRecipe(input: CreateRecipeInput): Promise<Recipe> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    throw new Error("Not authenticated");
+  }
+  const userId = parseInt(session.user.id, 10);
+
+  return transaction(async (client) => {
+    const slug = await getUniqueSlug(userId, input.title);
+
+    // Check if slug exists, increment version if so
+    const existingResult = await client.query<{ version: number }>(
+      `SELECT MAX(version) as version FROM recipes WHERE user_id = $1 AND slug = $2`,
+      [userId, slug]
+    );
+    const version = (existingResult.rows[0]?.version || 0) + 1;
+
+    // Deactivate previous versions
+    await client.query(
+      `UPDATE recipes SET is_active = false WHERE user_id = $1 AND slug = $2`,
+      [userId, slug]
+    );
+
+    // Create new recipe
+    const result = await client.query<RecipeRow>(
+      `INSERT INTO recipes (
+        user_id, slug, version, title, description, locale, tags, recipe_json
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+      RETURNING *`,
+      [
+        userId,
+        slug,
+        version,
+        input.title,
+        input.description || null,
+        input.locale || "de-DE",
+        JSON.stringify(input.tags || []),
+        JSON.stringify(input.recipeJson),
+      ]
+    );
+
+    return rowToRecipe(result.rows[0]);
+  });
+}
+
+/**
+ * Update an existing recipe (creates new version)
+ */
+export async function updateRecipe(
+  slug: string,
+  input: UpdateRecipeInput
+): Promise<Recipe> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    throw new Error("Not authenticated");
+  }
+  const userId = parseInt(session.user.id, 10);
+
+  return transaction(async (client) => {
+    // Get current recipe
+    const currentResult = await client.query<RecipeRow>(
+      `SELECT * FROM recipes
+       WHERE user_id = $1 AND slug = $2 AND is_active = true
+       ORDER BY version DESC LIMIT 1`,
+      [userId, slug]
+    );
+
+    if (currentResult.rows.length === 0) {
+      throw new Error("Recipe not found");
+    }
+
+    const current = currentResult.rows[0];
+    const newVersion = current.version + 1;
+
+    // Deactivate current version
+    await client.query(`UPDATE recipes SET is_active = false WHERE id = $1`, [
+      current.id,
+    ]);
+
+    // Create new version
+    const result = await client.query<RecipeRow>(
+      `INSERT INTO recipes (
+        user_id, slug, version, title, description, locale, tags, recipe_json
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+      RETURNING *`,
+      [
+        userId,
+        slug,
+        newVersion,
+        input.title ?? current.title,
+        input.description !== undefined
+          ? input.description
+          : current.description,
+        input.locale ?? current.locale,
+        JSON.stringify(input.tags ?? current.tags),
+        JSON.stringify(input.recipeJson ?? current.recipe_json),
+      ]
+    );
+
+    return rowToRecipe(result.rows[0]);
+  });
+}
+
+/**
+ * Delete a recipe (soft delete)
+ */
+export async function deleteRecipe(slug: string): Promise<void> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    throw new Error("Not authenticated");
+  }
+  const userId = parseInt(session.user.id, 10);
+
+  await query(
+    `UPDATE recipes SET is_active = false WHERE user_id = $1 AND slug = $2`,
+    [userId, slug]
+  );
+}
+
+/**
+ * Get all unique tags used by the current user
+ */
+export async function getUserTags(): Promise<string[]> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    throw new Error("Not authenticated");
+  }
+  const userId = parseInt(session.user.id, 10);
+
+  const result = await query<{ tag: string }>(
+    `SELECT DISTINCT jsonb_array_elements_text(tags) as tag
+     FROM recipes
+     WHERE user_id = $1 AND is_active = true
+     ORDER BY tag`,
+    [userId]
+  );
+
+  return result.rows.map((row) => row.tag);
+}


### PR DESCRIPTION
## Summary

Implements GitHub Issue #50 - Recipes feature database schema.

- Add PostgreSQL migration (`011_recipes.sql`) with JSONB storage pattern following workouts table design
- Add JSONB `tags` column with GIN index for efficient tag-based filtering  
- Add full-text search index (German language) for recipe search
- Add unique partial index ensuring only one active recipe per user/slug
- Add `locale` column for multi-language support
- Create TypeScript types and data access layer (`recipes.ts`, `recipe-types.ts`)
- Add REST API endpoints for CRUD operations (`/api/recipes`)

### Key Schema Decisions

| Column | Type | Purpose |
|--------|------|---------|
| `slug` | VARCHAR(200) | URL-friendly identifier |
| `version` | INTEGER | Enables recipe versioning |
| `tags` | JSONB | String array for flexible tagging |
| `locale` | VARCHAR(10) | Language filtering (default: de-DE) |
| `recipe_json` | JSONB | Stores ingredients, instructions, metadata |

## Test plan

- [x] `npm run lint` passes (only pre-existing warnings)
- [x] `npm run build` compiles successfully
- [x] `npm run test:unit` passes (56 tests)
- [x] Manual testing: API endpoints return expected responses

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)