### PR TITLE
feat: remove rest periods from nano workout

### DIFF
--- a/src/lib/nanoWorkout.ts
+++ b/src/lib/nanoWorkout.ts
@@ -15,18 +15,18 @@ export type NanoWorkout = {
 export const NANO_WEEKLY_LIMIT = 2;
 
 /**
- * The nano workout is a 3-minute minimal workout for maintaining streaks
+ * The nano workout is a 2.5-minute minimal workout for maintaining streaks
  * on days when motivation is low, traveling, or feeling unwell.
  *
  * Consists of: 10 squats, 10 push-ups, 10 crunches
- * With short rests between exercises.
+ * No rest periods between exercises for better flow.
  */
 export const NANO_WORKOUT: NanoWorkout = {
   slug: "nano",
   title: "Nano Workout",
   focus: "Streak saver",
-  description: "A quick 3-minute workout to maintain your streak on tough days. Just 10 squats, 10 push-ups, and 10 crunches.",
-  totalSeconds: 180,
+  description: "A quick 2.5-minute workout to maintain your streak on tough days. Just 10 squats, 10 push-ups, and 10 crunches.",
+  totalSeconds: 150,
   segments: [
     {
       id: "nano-prep",
@@ -43,25 +43,11 @@ export const NANO_WORKOUT: NanoWorkout = {
       category: "main",
     },
     {
-      id: "nano-rest-1",
-      title: "Rest",
-      durationSeconds: 15,
-      detail: "Breathe",
-      category: "rest",
-    },
-    {
       id: "nano-pushups",
       title: "Push-ups",
       durationSeconds: 45,
       detail: "10 reps - hands wide, chest to floor, push up strong",
       category: "main",
-    },
-    {
-      id: "nano-rest-2",
-      title: "Rest",
-      durationSeconds: 15,
-      detail: "Breathe",
-      category: "rest",
     },
     {
       id: "nano-crunches",


### PR DESCRIPTION
## Summary
- Removed two 15-second rest periods from the Nano workout
- Updated total duration from 3 minutes (180s) to 2.5 minutes (150s)
- Updated description text to reflect the new duration

## Related Issue
Closes #48

## Test Plan
- [x] Lint passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [x] Unit tests pass (`npm run test:unit`)
- [x] Manual testing confirms:
  - Nano workout preview shows "2.5-minute workout" and "5 steps"
  - Workout player transitions directly from Squats → Push-ups → Crunches (no rest)
  - Timeline shows only 5 segments (Prep, Squats, Push-ups, Crunches, Done)

🤖 Generated with [Claude Code](https://claude.com/claude-code)