### PR TITLE
feat: enhance recipe types with ingredient groups, multiple images, and time fields

### DIFF
--- a/src/lib/__tests__/recipe-types.test.ts
+++ b/src/lib/__tests__/recipe-types.test.ts
@@ -1,0 +1,522 @@
+import { describe, it, expect } from "vitest";
+import {
+  generateSlug,
+  getPrimaryImage,
+  toRecipeSummary,
+  getTotalTimeMinutes,
+  getAllIngredients,
+  getIngredientCount,
+  isValidNutritionInfo,
+  isValidIngredient,
+  isValidIngredientGroup,
+  isValidRecipeStep,
+  isValidRecipeImage,
+  isValidRecipeJson,
+  type Recipe,
+  type RecipeJson,
+  type RecipeImage,
+  type IngredientGroup,
+} from "../recipe-types";
+
+describe("Recipe Types", () => {
+  describe("generateSlug", () => {
+    it("converts title to lowercase", () => {
+      expect(generateSlug("Hello World")).toBe("hello-world");
+    });
+
+    it("replaces spaces with hyphens", () => {
+      expect(generateSlug("protein pancakes")).toBe("protein-pancakes");
+    });
+
+    it("removes diacritics (German umlauts)", () => {
+      expect(generateSlug("Käsekuchen")).toBe("kasekuchen");
+      expect(generateSlug("Müsli")).toBe("musli");
+      expect(generateSlug("Brötchen")).toBe("brotchen");
+    });
+
+    it("removes special characters", () => {
+      expect(generateSlug("Recipe #1!")).toBe("recipe-1");
+      expect(generateSlug("Pasta & Cheese")).toBe("pasta-cheese");
+    });
+
+    it("trims leading and trailing hyphens", () => {
+      expect(generateSlug("  spaces around  ")).toBe("spaces-around");
+      expect(generateSlug("---leading")).toBe("leading");
+      expect(generateSlug("trailing---")).toBe("trailing");
+    });
+
+    it("truncates to 200 characters", () => {
+      const longTitle = "a".repeat(250);
+      expect(generateSlug(longTitle).length).toBe(200);
+    });
+
+    it("handles empty string", () => {
+      expect(generateSlug("")).toBe("");
+    });
+
+    it("handles numbers in title", () => {
+      expect(generateSlug("Recipe 123")).toBe("recipe-123");
+    });
+  });
+
+  describe("getPrimaryImage", () => {
+    it("returns undefined for empty array", () => {
+      expect(getPrimaryImage([])).toBeUndefined();
+    });
+
+    it("returns first image if none marked as primary", () => {
+      const images: RecipeImage[] = [
+        { url: "/img/1.jpg" },
+        { url: "/img/2.jpg" },
+      ];
+      expect(getPrimaryImage(images)).toEqual({ url: "/img/1.jpg" });
+    });
+
+    it("returns image marked as primary", () => {
+      const images: RecipeImage[] = [
+        { url: "/img/1.jpg" },
+        { url: "/img/2.jpg", isPrimary: true },
+        { url: "/img/3.jpg" },
+      ];
+      expect(getPrimaryImage(images)).toEqual({
+        url: "/img/2.jpg",
+        isPrimary: true,
+      });
+    });
+
+    it("returns first primary if multiple marked", () => {
+      const images: RecipeImage[] = [
+        { url: "/img/1.jpg", isPrimary: true },
+        { url: "/img/2.jpg", isPrimary: true },
+      ];
+      expect(getPrimaryImage(images)).toEqual({
+        url: "/img/1.jpg",
+        isPrimary: true,
+      });
+    });
+  });
+
+  describe("getTotalTimeMinutes", () => {
+    const baseRecipe: RecipeJson = {
+      slug: "test",
+      title: "Test",
+      description: "Test",
+      tags: [],
+      servings: 1,
+      nutrition: { calories: 100, protein: 10, carbohydrates: 20, fat: 5 },
+      ingredientGroups: [],
+      steps: [],
+      images: [{ url: "/img.jpg" }],
+      locale: "en-US",
+    };
+
+    it("returns undefined when both times are undefined", () => {
+      expect(getTotalTimeMinutes(baseRecipe)).toBeUndefined();
+    });
+
+    it("returns prep time when only prep is defined", () => {
+      expect(
+        getTotalTimeMinutes({ ...baseRecipe, prepTimeMinutes: 10 })
+      ).toBe(10);
+    });
+
+    it("returns cook time when only cook is defined", () => {
+      expect(
+        getTotalTimeMinutes({ ...baseRecipe, cookTimeMinutes: 30 })
+      ).toBe(30);
+    });
+
+    it("returns sum of both times", () => {
+      expect(
+        getTotalTimeMinutes({
+          ...baseRecipe,
+          prepTimeMinutes: 15,
+          cookTimeMinutes: 45,
+        })
+      ).toBe(60);
+    });
+  });
+
+  describe("getAllIngredients", () => {
+    it("returns empty array for no groups", () => {
+      const recipe: RecipeJson = {
+        slug: "test",
+        title: "Test",
+        description: "Test",
+        tags: [],
+        servings: 1,
+        nutrition: { calories: 100, protein: 10, carbohydrates: 20, fat: 5 },
+        ingredientGroups: [],
+        steps: [],
+        images: [{ url: "/img.jpg" }],
+        locale: "en-US",
+      };
+      expect(getAllIngredients(recipe)).toEqual([]);
+    });
+
+    it("flattens ingredients from all groups", () => {
+      const recipe: RecipeJson = {
+        slug: "test",
+        title: "Test",
+        description: "Test",
+        tags: [],
+        servings: 1,
+        nutrition: { calories: 100, protein: 10, carbohydrates: 20, fat: 5 },
+        ingredientGroups: [
+          {
+            name: "Dairy",
+            ingredients: [
+              { name: "Milk", quantity: 200, unit: "ml" },
+              { name: "Cheese", quantity: 50, unit: "g" },
+            ],
+          },
+          {
+            name: "Protein",
+            ingredients: [{ name: "Whey", quantity: 30, unit: "g" }],
+          },
+        ],
+        steps: [],
+        images: [{ url: "/img.jpg" }],
+        locale: "en-US",
+      };
+      const ingredients = getAllIngredients(recipe);
+      expect(ingredients).toHaveLength(3);
+      expect(ingredients[0].name).toBe("Milk");
+      expect(ingredients[2].name).toBe("Whey");
+    });
+  });
+
+  describe("getIngredientCount", () => {
+    it("returns 0 for no ingredients", () => {
+      const recipe: RecipeJson = {
+        slug: "test",
+        title: "Test",
+        description: "Test",
+        tags: [],
+        servings: 1,
+        nutrition: { calories: 100, protein: 10, carbohydrates: 20, fat: 5 },
+        ingredientGroups: [],
+        steps: [],
+        images: [{ url: "/img.jpg" }],
+        locale: "en-US",
+      };
+      expect(getIngredientCount(recipe)).toBe(0);
+    });
+
+    it("counts all ingredients across groups", () => {
+      const recipe: RecipeJson = {
+        slug: "test",
+        title: "Test",
+        description: "Test",
+        tags: [],
+        servings: 1,
+        nutrition: { calories: 100, protein: 10, carbohydrates: 20, fat: 5 },
+        ingredientGroups: [
+          {
+            name: "Group 1",
+            ingredients: [
+              { name: "A", quantity: 1, unit: "g" },
+              { name: "B", quantity: 1, unit: "g" },
+            ],
+          },
+          {
+            name: "Group 2",
+            ingredients: [{ name: "C", quantity: 1, unit: "g" }],
+          },
+        ],
+        steps: [],
+        images: [{ url: "/img.jpg" }],
+        locale: "en-US",
+      };
+      expect(getIngredientCount(recipe)).toBe(3);
+    });
+  });
+
+  describe("toRecipeSummary", () => {
+    it("extracts summary fields from full recipe", () => {
+      const recipe: Recipe = {
+        id: 1,
+        userId: 1,
+        slug: "test-recipe",
+        version: 1,
+        title: "Test Recipe",
+        description: "A test recipe description",
+        locale: "en-US",
+        tags: ["breakfast", "high-protein"],
+        recipeJson: {
+          slug: "test-recipe",
+          title: "Test Recipe",
+          description: "JSON description",
+          tags: ["breakfast", "high-protein"],
+          servings: 2,
+          prepTimeMinutes: 10,
+          cookTimeMinutes: 20,
+          nutrition: { calories: 300, protein: 25, carbohydrates: 30, fat: 10 },
+          ingredientGroups: [
+            {
+              name: "Main",
+              ingredients: [{ name: "Oats", quantity: 100, unit: "g" }],
+            },
+          ],
+          steps: [{ number: 1, instruction: "Mix ingredients" }],
+          images: [
+            { url: "/img1.jpg" },
+            { url: "/img2.jpg", isPrimary: true },
+          ],
+          locale: "en-US",
+        },
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      const summary = toRecipeSummary(recipe);
+
+      expect(summary.slug).toBe("test-recipe");
+      expect(summary.title).toBe("Test Recipe");
+      expect(summary.description).toBe("A test recipe description");
+      expect(summary.tags).toEqual(["breakfast", "high-protein"]);
+      expect(summary.servings).toBe(2);
+      expect(summary.prepTimeMinutes).toBe(10);
+      expect(summary.cookTimeMinutes).toBe(20);
+      expect(summary.primaryImage?.url).toBe("/img2.jpg");
+      expect(summary.nutrition.calories).toBe(300);
+    });
+
+    it("uses recipeJson description when recipe description is null", () => {
+      const recipe: Recipe = {
+        id: 1,
+        userId: 1,
+        slug: "test",
+        version: 1,
+        title: "Test",
+        description: null,
+        locale: "en-US",
+        tags: [],
+        recipeJson: {
+          slug: "test",
+          title: "Test",
+          description: "Fallback description",
+          tags: [],
+          servings: 1,
+          nutrition: { calories: 100, protein: 10, carbohydrates: 20, fat: 5 },
+          ingredientGroups: [],
+          steps: [],
+          images: [{ url: "/img.jpg" }],
+          locale: "en-US",
+        },
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      const summary = toRecipeSummary(recipe);
+      expect(summary.description).toBe("Fallback description");
+    });
+  });
+
+  describe("Type Guards", () => {
+    describe("isValidNutritionInfo", () => {
+      it("returns true for valid nutrition info", () => {
+        expect(
+          isValidNutritionInfo({
+            calories: 100,
+            protein: 10,
+            carbohydrates: 20,
+            fat: 5,
+          })
+        ).toBe(true);
+      });
+
+      it("returns true with optional fiber", () => {
+        expect(
+          isValidNutritionInfo({
+            calories: 100,
+            protein: 10,
+            carbohydrates: 20,
+            fat: 5,
+            fiber: 3,
+          })
+        ).toBe(true);
+      });
+
+      it("returns false for missing required fields", () => {
+        expect(isValidNutritionInfo({ calories: 100 })).toBe(false);
+        expect(isValidNutritionInfo({ protein: 10 })).toBe(false);
+      });
+
+      it("returns false for non-object", () => {
+        expect(isValidNutritionInfo(null)).toBe(false);
+        expect(isValidNutritionInfo("string")).toBe(false);
+        expect(isValidNutritionInfo(123)).toBe(false);
+      });
+
+      it("returns false for wrong types", () => {
+        expect(
+          isValidNutritionInfo({
+            calories: "100",
+            protein: 10,
+            carbohydrates: 20,
+            fat: 5,
+          })
+        ).toBe(false);
+      });
+    });
+
+    describe("isValidIngredient", () => {
+      it("returns true for valid ingredient", () => {
+        expect(
+          isValidIngredient({ name: "Oats", quantity: 100, unit: "g" })
+        ).toBe(true);
+      });
+
+      it("returns false for missing fields", () => {
+        expect(isValidIngredient({ name: "Oats" })).toBe(false);
+        expect(isValidIngredient({ name: "Oats", quantity: 100 })).toBe(false);
+      });
+
+      it("returns false for wrong types", () => {
+        expect(
+          isValidIngredient({ name: "Oats", quantity: "100", unit: "g" })
+        ).toBe(false);
+      });
+    });
+
+    describe("isValidIngredientGroup", () => {
+      it("returns true for valid group", () => {
+        const group: IngredientGroup = {
+          name: "Dairy",
+          ingredients: [{ name: "Milk", quantity: 200, unit: "ml" }],
+        };
+        expect(isValidIngredientGroup(group)).toBe(true);
+      });
+
+      it("returns true for empty ingredients array", () => {
+        expect(
+          isValidIngredientGroup({ name: "Empty", ingredients: [] })
+        ).toBe(true);
+      });
+
+      it("returns false for invalid ingredient in group", () => {
+        expect(
+          isValidIngredientGroup({
+            name: "Invalid",
+            ingredients: [{ name: "Bad", quantity: "not a number" }],
+          })
+        ).toBe(false);
+      });
+    });
+
+    describe("isValidRecipeStep", () => {
+      it("returns true for valid step", () => {
+        expect(
+          isValidRecipeStep({ number: 1, instruction: "Mix well" })
+        ).toBe(true);
+      });
+
+      it("returns false for missing instruction", () => {
+        expect(isValidRecipeStep({ number: 1 })).toBe(false);
+      });
+
+      it("returns false for wrong types", () => {
+        expect(
+          isValidRecipeStep({ number: "1", instruction: "Mix" })
+        ).toBe(false);
+      });
+    });
+
+    describe("isValidRecipeImage", () => {
+      it("returns true for valid image", () => {
+        expect(isValidRecipeImage({ url: "/img.jpg" })).toBe(true);
+      });
+
+      it("returns true with optional fields", () => {
+        expect(
+          isValidRecipeImage({
+            url: "/img.jpg",
+            caption: "Main dish",
+            isPrimary: true,
+          })
+        ).toBe(true);
+      });
+
+      it("returns false for missing url", () => {
+        expect(isValidRecipeImage({ caption: "No URL" })).toBe(false);
+      });
+
+      it("returns false for wrong types", () => {
+        expect(isValidRecipeImage({ url: 123 })).toBe(false);
+        expect(
+          isValidRecipeImage({ url: "/img.jpg", isPrimary: "true" })
+        ).toBe(false);
+      });
+    });
+
+    describe("isValidRecipeJson", () => {
+      const validRecipe: RecipeJson = {
+        slug: "test-recipe",
+        title: "Test Recipe",
+        description: "A test",
+        tags: ["breakfast"],
+        servings: 2,
+        nutrition: { calories: 100, protein: 10, carbohydrates: 20, fat: 5 },
+        ingredientGroups: [
+          {
+            name: "Main",
+            ingredients: [{ name: "Oats", quantity: 100, unit: "g" }],
+          },
+        ],
+        steps: [{ number: 1, instruction: "Mix" }],
+        images: [{ url: "/img.jpg" }],
+        locale: "en-US",
+      };
+
+      it("returns true for valid recipe", () => {
+        expect(isValidRecipeJson(validRecipe)).toBe(true);
+      });
+
+      it("returns true with optional fields", () => {
+        expect(
+          isValidRecipeJson({
+            ...validRecipe,
+            prepTimeMinutes: 10,
+            cookTimeMinutes: 20,
+          })
+        ).toBe(true);
+      });
+
+      it("returns false for missing required fields", () => {
+        const { slug: _slug, ...noSlug } = validRecipe;
+        expect(isValidRecipeJson(noSlug)).toBe(false);
+      });
+
+      it("returns false for empty images array", () => {
+        expect(isValidRecipeJson({ ...validRecipe, images: [] })).toBe(false);
+      });
+
+      it("returns false for more than 10 images", () => {
+        const tooManyImages = Array(11)
+          .fill(null)
+          .map((_, i) => ({ url: `/img${i}.jpg` }));
+        expect(
+          isValidRecipeJson({ ...validRecipe, images: tooManyImages })
+        ).toBe(false);
+      });
+
+      it("returns false for invalid nested objects", () => {
+        expect(
+          isValidRecipeJson({
+            ...validRecipe,
+            nutrition: { calories: "not a number" },
+          })
+        ).toBe(false);
+      });
+
+      it("returns false for non-string tags", () => {
+        expect(
+          isValidRecipeJson({ ...validRecipe, tags: [1, 2, 3] })
+        ).toBe(false);
+      });
+    });
+  });
+});

--- a/src/lib/recipe-types.ts
+++ b/src/lib/recipe-types.ts
@@ -3,49 +3,89 @@
  * Follows workout pattern with JSONB storage and versioning
  */
 
-export interface Ingredient {
-  id: string;
-  name: string;
-  amount: number;
-  unit: string;
-  notes?: string;
-  isOptional?: boolean;
-}
+// ============================================
+// Core Recipe Types
+// ============================================
 
-export interface InstructionStep {
-  id: string;
-  step: number;
-  text: string;
-  durationMinutes?: number;
-  tip?: string;
-}
-
-export interface NutritionInfo {
-  calories?: number;
-  protein?: number;
-  carbs?: number;
-  fat?: number;
+export type NutritionInfo = {
+  calories: number;
+  protein: number;
+  carbohydrates: number;
+  fat: number;
   fiber?: number;
-  sodium?: number;
-}
+};
+
+export type Ingredient = {
+  name: string;
+  quantity: number;
+  unit: string;
+};
+
+export type IngredientGroup = {
+  name: string; // e.g., "Milchprodukte", "Proteinpulver"
+  ingredients: Ingredient[];
+};
+
+export type RecipeStep = {
+  number: number;
+  instruction: string;
+};
+
+export type RecipeImage = {
+  url: string;
+  caption?: string;
+  isPrimary?: boolean;
+};
 
 export type RecipeSourceType = "manual" | "imported" | "shared" | "ai_generated";
 
-export interface RecipeJson {
-  ingredients: Ingredient[];
-  instructions: InstructionStep[];
-  nutrition?: NutritionInfo;
-  notes?: string;
-  imageUrl?: string;
-  // Metadata fields stored in JSONB
-  prepTimeMinutes?: number;
-  cookTimeMinutes?: number;
-  servings?: number;
+/**
+ * Full recipe data stored in JSONB
+ * This is what gets stored in recipe_json column
+ */
+export type RecipeJson = {
+  slug: string; // URL-friendly ID from title
+  title: string;
+  description: string;
+  tags: string[];
+  servings: number;
+  prepTimeMinutes?: number; // Preparation time
+  cookTimeMinutes?: number; // Cooking time
+  nutrition: NutritionInfo;
+  ingredientGroups: IngredientGroup[];
+  steps: RecipeStep[];
+  images: RecipeImage[]; // 1-10 images required
+  locale: string; // e.g., "de-DE", "en-US"
+  // Metadata
   sourceType?: RecipeSourceType;
   sourceUrl?: string;
   isFavorite?: boolean;
   rating?: number;
-}
+  notes?: string;
+};
+
+// ============================================
+// List/Summary Types
+// ============================================
+
+/**
+ * Summary type for list views (lightweight, no full recipe data)
+ */
+export type RecipeSummary = {
+  slug: string;
+  title: string;
+  description: string;
+  tags: string[];
+  servings: number;
+  prepTimeMinutes?: number;
+  cookTimeMinutes?: number;
+  primaryImage?: RecipeImage;
+  nutrition: NutritionInfo;
+};
+
+// ============================================
+// Database Types
+// ============================================
 
 export interface Recipe {
   id: number;
@@ -96,7 +136,10 @@ export function rowToRecipe(row: RecipeRow): Recipe {
   };
 }
 
-// Input types for creating/updating
+// ============================================
+// Input Types
+// ============================================
+
 export interface CreateRecipeInput {
   title: string;
   description?: string;
@@ -111,4 +154,148 @@ export interface UpdateRecipeInput {
   locale?: string;
   tags?: string[];
   recipeJson?: RecipeJson;
+}
+
+// ============================================
+// Helper Functions
+// ============================================
+
+/**
+ * Generate a URL-friendly slug from a title
+ */
+export function generateSlug(title: string): string {
+  return title
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "") // Remove diacritics (ä→a, ü→u, etc.)
+    .replace(/[^a-z0-9]+/g, "-") // Replace non-alphanumeric with hyphens
+    .replace(/^-+|-+$/g, "") // Trim leading/trailing hyphens
+    .substring(0, 200); // Max length
+}
+
+/**
+ * Get the primary image from a recipe, or the first image if none is marked primary
+ */
+export function getPrimaryImage(images: RecipeImage[]): RecipeImage | undefined {
+  if (images.length === 0) return undefined;
+  return images.find((img) => img.isPrimary) ?? images[0];
+}
+
+/**
+ * Convert a full Recipe to a RecipeSummary for list views
+ */
+export function toRecipeSummary(recipe: Recipe): RecipeSummary {
+  const { recipeJson } = recipe;
+  return {
+    slug: recipe.slug,
+    title: recipe.title,
+    description: recipe.description ?? recipeJson.description,
+    tags: recipe.tags,
+    servings: recipeJson.servings,
+    prepTimeMinutes: recipeJson.prepTimeMinutes,
+    cookTimeMinutes: recipeJson.cookTimeMinutes,
+    primaryImage: getPrimaryImage(recipeJson.images),
+    nutrition: recipeJson.nutrition,
+  };
+}
+
+/**
+ * Calculate total time (prep + cook) in minutes
+ */
+export function getTotalTimeMinutes(recipe: RecipeJson): number | undefined {
+  if (recipe.prepTimeMinutes === undefined && recipe.cookTimeMinutes === undefined) {
+    return undefined;
+  }
+  return (recipe.prepTimeMinutes ?? 0) + (recipe.cookTimeMinutes ?? 0);
+}
+
+/**
+ * Get all ingredients from all groups as a flat list
+ */
+export function getAllIngredients(recipe: RecipeJson): Ingredient[] {
+  return recipe.ingredientGroups.flatMap((group) => group.ingredients);
+}
+
+/**
+ * Count total number of ingredients across all groups
+ */
+export function getIngredientCount(recipe: RecipeJson): number {
+  return getAllIngredients(recipe).length;
+}
+
+// ============================================
+// Type Guards
+// ============================================
+
+export function isValidNutritionInfo(obj: unknown): obj is NutritionInfo {
+  if (typeof obj !== "object" || obj === null) return false;
+  const nutrition = obj as Record<string, unknown>;
+  return (
+    typeof nutrition.calories === "number" &&
+    typeof nutrition.protein === "number" &&
+    typeof nutrition.carbohydrates === "number" &&
+    typeof nutrition.fat === "number" &&
+    (nutrition.fiber === undefined || typeof nutrition.fiber === "number")
+  );
+}
+
+export function isValidIngredient(obj: unknown): obj is Ingredient {
+  if (typeof obj !== "object" || obj === null) return false;
+  const ingredient = obj as Record<string, unknown>;
+  return (
+    typeof ingredient.name === "string" &&
+    typeof ingredient.quantity === "number" &&
+    typeof ingredient.unit === "string"
+  );
+}
+
+export function isValidIngredientGroup(obj: unknown): obj is IngredientGroup {
+  if (typeof obj !== "object" || obj === null) return false;
+  const group = obj as Record<string, unknown>;
+  return (
+    typeof group.name === "string" &&
+    Array.isArray(group.ingredients) &&
+    group.ingredients.every(isValidIngredient)
+  );
+}
+
+export function isValidRecipeStep(obj: unknown): obj is RecipeStep {
+  if (typeof obj !== "object" || obj === null) return false;
+  const step = obj as Record<string, unknown>;
+  return typeof step.number === "number" && typeof step.instruction === "string";
+}
+
+export function isValidRecipeImage(obj: unknown): obj is RecipeImage {
+  if (typeof obj !== "object" || obj === null) return false;
+  const image = obj as Record<string, unknown>;
+  return (
+    typeof image.url === "string" &&
+    (image.caption === undefined || typeof image.caption === "string") &&
+    (image.isPrimary === undefined || typeof image.isPrimary === "boolean")
+  );
+}
+
+export function isValidRecipeJson(obj: unknown): obj is RecipeJson {
+  if (typeof obj !== "object" || obj === null) return false;
+  const recipe = obj as Record<string, unknown>;
+  return (
+    typeof recipe.slug === "string" &&
+    typeof recipe.title === "string" &&
+    typeof recipe.description === "string" &&
+    Array.isArray(recipe.tags) &&
+    recipe.tags.every((tag) => typeof tag === "string") &&
+    typeof recipe.servings === "number" &&
+    (recipe.prepTimeMinutes === undefined || typeof recipe.prepTimeMinutes === "number") &&
+    (recipe.cookTimeMinutes === undefined || typeof recipe.cookTimeMinutes === "number") &&
+    isValidNutritionInfo(recipe.nutrition) &&
+    Array.isArray(recipe.ingredientGroups) &&
+    recipe.ingredientGroups.every(isValidIngredientGroup) &&
+    Array.isArray(recipe.steps) &&
+    recipe.steps.every(isValidRecipeStep) &&
+    Array.isArray(recipe.images) &&
+    recipe.images.length >= 1 &&
+    recipe.images.length <= 10 &&
+    recipe.images.every(isValidRecipeImage) &&
+    typeof recipe.locale === "string"
+  );
 }

--- a/src/lib/recipes.ts
+++ b/src/lib/recipes.ts
@@ -11,20 +11,11 @@ import {
   CreateRecipeInput,
   UpdateRecipeInput,
   rowToRecipe,
+  generateSlug,
 } from "./recipe-types";
 
-/**
- * Generate a URL-friendly slug from a recipe title
- */
-export function generateSlug(title: string): string {
-  return title
-    .toLowerCase()
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "") // Remove diacritics (ä→a, ü→u, etc.)
-    .replace(/[^a-z0-9]+/g, "-") // Replace non-alphanumeric with hyphens
-    .replace(/^-+|-+$/g, "") // Trim leading/trailing hyphens
-    .substring(0, 200); // Max length
-}
+// Re-export generateSlug for backwards compatibility
+export { generateSlug };
 
 /**
  * Check if a slug exists for a user


### PR DESCRIPTION
## Summary

Updates the recipe type system in `src/lib/recipe-types.ts` to match the enhanced specification from issue #51:

- **Ingredient groups**: Support for grouping ingredients (e.g., "Dairy", "Protein") with structured `IngredientGroup` type
- **Multiple images**: Support for 1-10 images per recipe with `RecipeImage` type (url, caption, isPrimary)
- **Time fields**: Added `prepTimeMinutes` and `cookTimeMinutes` to `RecipeJson`
- **Helper functions**: `getPrimaryImage`, `toRecipeSummary`, `getTotalTimeMinutes`, `getAllIngredients`, `getIngredientCount`
- **Type guards**: Validation functions for all types (`isValidNutritionInfo`, `isValidIngredient`, `isValidRecipeJson`, etc.)
- **RecipeSummary type**: Lightweight type for list views

Also moved `generateSlug` function to `recipe-types.ts` and re-exported from `recipes.ts` for backwards compatibility.

## Test plan

- [x] All 47 unit tests pass (`npm run test:unit`)
- [x] Lint passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [x] Manual testing with Playwright - app loads and functions correctly

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)