### PR TITLE
feat: add bottom navigation bar for Home and Recipes tabs

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { BottomNav } from "@/components/BottomNav";
 import { ChatButton } from "@/components/ChatButton";
 import { ChatProvider } from "@/contexts/ChatContext";
 import { MainContentWrapper } from "@/components/MainContentWrapper";
@@ -62,6 +63,7 @@ export default async function RootLayout({
           <MainContentWrapper>
             {children}
           </MainContentWrapper>
+          {session?.user && <BottomNav />}
           {session?.user && <ChatButton />}
         </ChatProvider>
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -56,7 +56,7 @@ export default async function Home() {
 
   return (
     <main className="min-h-screen bg-slate-950 text-slate-100">
-      <div className="mx-auto flex max-w-3xl flex-col gap-8 px-5 pb-16 pt-12 sm:px-8">
+      <div className="mx-auto flex max-w-3xl flex-col gap-8 px-5 pb-24 pt-12 sm:px-8">
         {/* Header */}
         <header className="flex items-center justify-between">
           <p className="text-xs font-semibold uppercase tracking-[0.4em] text-emerald-400">

--- a/src/app/recipes/page.tsx
+++ b/src/app/recipes/page.tsx
@@ -1,0 +1,30 @@
+import { auth } from "@/lib/auth";
+import { redirect } from "next/navigation";
+
+export default async function RecipesPage() {
+  const session = await auth();
+  if (!session?.user) {
+    redirect("/login");
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-950 text-slate-100">
+      <div className="mx-auto flex max-w-3xl flex-col gap-8 px-5 pb-24 pt-12 sm:px-8">
+        <header>
+          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-emerald-400">
+            FitStreak
+          </p>
+        </header>
+
+        <section className="space-y-4">
+          <h1 className="text-2xl font-semibold text-white sm:text-3xl">
+            Recipes
+          </h1>
+          <p className="text-slate-400">
+            Your healthy recipes will appear here.
+          </p>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+// Only show on these exact paths
+const VISIBLE_PATHS = ['/', '/recipes'];
+
+export function BottomNav() {
+  const pathname = usePathname();
+
+  // Hide on all pages except main list pages
+  if (!VISIBLE_PATHS.includes(pathname)) {
+    return null;
+  }
+
+  return (
+    <nav className="fixed bottom-0 left-0 right-0 z-50 h-16 bg-slate-900/95 backdrop-blur-sm border-t border-slate-800 pb-[env(safe-area-inset-bottom)]">
+      <div className="flex h-full items-center justify-around max-w-3xl mx-auto">
+        <Link
+          href="/"
+          className={`flex flex-col items-center justify-center gap-1 px-6 py-2 ${
+            pathname === '/' ? 'text-emerald-400' : 'text-slate-400 hover:text-slate-200'
+          }`}
+        >
+          {/* Home icon */}
+          <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+          </svg>
+          <span className="text-xs font-medium">Home</span>
+        </Link>
+
+        <Link
+          href="/recipes"
+          className={`flex flex-col items-center justify-center gap-1 px-6 py-2 ${
+            pathname === '/recipes' ? 'text-emerald-400' : 'text-slate-400 hover:text-slate-200'
+          }`}
+        >
+          {/* Recipes icon (utensils) */}
+          <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+          </svg>
+          <span className="text-xs font-medium">Recipes</span>
+        </Link>
+      </div>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a fixed bottom navigation bar with Home and Recipes tabs
- Navigation only displays on main list pages (`/` and `/recipes`)
- Active tab is highlighted with emerald color to match app theme
- Includes safe area support for notched devices (iPhone, etc.)
- Created stub recipes page as navigation target

## Test plan
- [x] Bottom nav appears on home page (`/`)
- [x] Bottom nav appears on recipes page (`/recipes`)
- [x] Bottom nav is hidden on workout detail pages
- [x] Active state toggles correctly when switching tabs
- [x] Lint passes with no new errors
- [x] Build succeeds
- [x] All 103 unit tests pass

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)