### PR TITLE
feat: add RecipeCard component for recipe list display

### DIFF
--- a/src/app/recipes/page.tsx
+++ b/src/app/recipes/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { getUserRecipeSummaries } from "@/lib/recipes";
 import { LogoutButton } from "@/components/LogoutButton";
+import { RecipeCard } from "@/components/RecipeCard";
 
 export const dynamic = "force-dynamic";
 
@@ -79,20 +80,10 @@ export default async function RecipesPage() {
             </div>
           </section>
         ) : (
-          /* Recipe list placeholder - will be implemented in future issue */
+          /* Recipe list */
           <section className="grid gap-3">
             {recipes.map((recipe) => (
-              <div
-                key={recipe.slug}
-                className="rounded-xl border border-slate-800 bg-slate-900/50 p-4"
-              >
-                <h3 className="font-medium text-white">{recipe.title}</h3>
-                {recipe.description && (
-                  <p className="mt-1 text-sm text-slate-400 line-clamp-2">
-                    {recipe.description}
-                  </p>
-                )}
-              </div>
+              <RecipeCard key={recipe.slug} recipe={recipe} />
             ))}
           </section>
         )}

--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useState } from "react";
+
+import { RecipeSummary } from "@/lib/recipe-types";
+
+interface RecipeCardProps {
+  recipe: RecipeSummary;
+  href?: string; // Optional override for navigation (defaults to /recipes/[slug])
+}
+
+/**
+ * Card component for displaying recipe summaries in a list view.
+ * Shows image, title, description, tags, time, and servings.
+ */
+export function RecipeCard({ recipe, href }: RecipeCardProps) {
+  const [imageError, setImageError] = useState(false);
+
+  const linkHref = href ?? `/recipes/${recipe.slug}`;
+  const hasImage = recipe.primaryImage?.url && !imageError;
+  const showTimes =
+    recipe.prepTimeMinutes !== undefined ||
+    recipe.cookTimeMinutes !== undefined;
+
+  // Format time display
+  const timeDisplay = (() => {
+    const parts: string[] = [];
+    if (recipe.prepTimeMinutes) {
+      parts.push(`${recipe.prepTimeMinutes}m prep`);
+    }
+    if (recipe.cookTimeMinutes) {
+      parts.push(`${recipe.cookTimeMinutes}m cook`);
+    }
+    return parts.join(" • ");
+  })();
+
+  // Servings display with proper singular/plural
+  const servingsDisplay = `${recipe.servings} ${recipe.servings === 1 ? "serving" : "servings"}`;
+
+  // Limit tags to 3
+  const visibleTags = recipe.tags.slice(0, 3);
+  const extraTagCount = recipe.tags.length - 3;
+
+  return (
+    <Link
+      href={linkHref}
+      className="block overflow-hidden rounded-xl border border-slate-800 bg-slate-900/50 transition-colors hover:border-slate-700"
+      aria-label={`View recipe: ${recipe.title}`}
+    >
+      {/* Image section */}
+      <div className="relative aspect-video w-full bg-slate-800">
+        {hasImage ? (
+          <Image
+            src={recipe.primaryImage!.url}
+            alt={recipe.primaryImage!.caption ?? recipe.title}
+            fill
+            className="object-cover"
+            onError={() => setImageError(true)}
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center text-4xl">
+            🍳
+          </div>
+        )}
+      </div>
+
+      {/* Content section */}
+      <div className="space-y-2 p-4">
+        {/* Title */}
+        <h3 className="truncate font-medium text-white">{recipe.title}</h3>
+
+        {/* Description */}
+        {recipe.description && (
+          <p className="line-clamp-2 text-sm text-slate-400">
+            {recipe.description}
+          </p>
+        )}
+
+        {/* Tags */}
+        {visibleTags.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {visibleTags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs text-emerald-400"
+              >
+                {tag}
+              </span>
+            ))}
+            {extraTagCount > 0 && (
+              <span className="inline-flex items-center rounded-full bg-slate-500/10 px-2 py-0.5 text-xs text-slate-400">
+                +{extraTagCount} more
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* Time and servings */}
+        {(showTimes || recipe.servings) && (
+          <div className="flex flex-wrap items-center gap-3 text-xs text-slate-500">
+            {showTimes && <span>🕐 {timeDisplay}</span>}
+            {recipe.servings && <span>👥 {servingsDisplay}</span>}
+          </div>
+        )}
+      </div>
+    </Link>
+  );
+}

--- a/src/components/__tests__/RecipeCard.test.tsx
+++ b/src/components/__tests__/RecipeCard.test.tsx
@@ -1,0 +1,161 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+import { RecipeSummary } from "@/lib/recipe-types";
+import { RecipeCard } from "../RecipeCard";
+
+// Mock next/image
+vi.mock("next/image", () => ({
+  default: ({
+    src,
+    alt,
+    onError,
+  }: {
+    src: string;
+    alt: string;
+    onError?: () => void;
+  }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src={src} alt={alt} onError={onError} data-testid="recipe-image" />
+  ),
+}));
+
+const mockRecipe: RecipeSummary = {
+  slug: "test-recipe",
+  title: "Test Recipe",
+  description: "A delicious test recipe for unit testing",
+  tags: ["healthy", "quick", "vegetarian"],
+  servings: 4,
+  prepTimeMinutes: 15,
+  cookTimeMinutes: 30,
+  primaryImage: {
+    url: "https://example.com/image.jpg",
+    caption: "Test recipe image",
+  },
+  nutrition: {
+    calories: 500,
+    protein: 25,
+    carbohydrates: 60,
+    fat: 15,
+  },
+};
+
+describe("RecipeCard", () => {
+  it("renders recipe title", () => {
+    render(<RecipeCard recipe={mockRecipe} />);
+    expect(screen.getByText("Test Recipe")).toBeInTheDocument();
+  });
+
+  it("renders recipe description", () => {
+    render(<RecipeCard recipe={mockRecipe} />);
+    expect(
+      screen.getByText("A delicious test recipe for unit testing")
+    ).toBeInTheDocument();
+  });
+
+  it("renders recipe tags (limited to 3)", () => {
+    render(<RecipeCard recipe={mockRecipe} />);
+    expect(screen.getByText("healthy")).toBeInTheDocument();
+    expect(screen.getByText("quick")).toBeInTheDocument();
+    expect(screen.getByText("vegetarian")).toBeInTheDocument();
+  });
+
+  it("renders +N more indicator when more than 3 tags", () => {
+    const recipeWithManyTags = {
+      ...mockRecipe,
+      tags: ["healthy", "quick", "vegetarian", "dinner", "lunch"],
+    };
+    render(<RecipeCard recipe={recipeWithManyTags} />);
+    expect(screen.getByText("+2 more")).toBeInTheDocument();
+  });
+
+  it("renders prep and cook time", () => {
+    render(<RecipeCard recipe={mockRecipe} />);
+    expect(screen.getByText("🕐 15m prep • 30m cook")).toBeInTheDocument();
+  });
+
+  it("renders only prep time when cook time is missing", () => {
+    const recipeWithOnlyPrep = {
+      ...mockRecipe,
+      cookTimeMinutes: undefined,
+    };
+    render(<RecipeCard recipe={recipeWithOnlyPrep} />);
+    expect(screen.getByText("🕐 15m prep")).toBeInTheDocument();
+  });
+
+  it("renders only cook time when prep time is missing", () => {
+    const recipeWithOnlyCook = {
+      ...mockRecipe,
+      prepTimeMinutes: undefined,
+    };
+    render(<RecipeCard recipe={recipeWithOnlyCook} />);
+    expect(screen.getByText("🕐 30m cook")).toBeInTheDocument();
+  });
+
+  it("renders servings with correct pluralization", () => {
+    render(<RecipeCard recipe={mockRecipe} />);
+    expect(screen.getByText("👥 4 servings")).toBeInTheDocument();
+  });
+
+  it("renders singular serving when servings is 1", () => {
+    const singleServing = { ...mockRecipe, servings: 1 };
+    render(<RecipeCard recipe={singleServing} />);
+    expect(screen.getByText("👥 1 serving")).toBeInTheDocument();
+  });
+
+  it("renders image when primaryImage is provided", () => {
+    render(<RecipeCard recipe={mockRecipe} />);
+    const image = screen.getByTestId("recipe-image");
+    expect(image).toHaveAttribute("src", "https://example.com/image.jpg");
+    expect(image).toHaveAttribute("alt", "Test recipe image");
+  });
+
+  it("renders placeholder emoji when no image", () => {
+    const recipeWithoutImage = {
+      ...mockRecipe,
+      primaryImage: undefined,
+    };
+    render(<RecipeCard recipe={recipeWithoutImage} />);
+    expect(screen.getByText("🍳")).toBeInTheDocument();
+  });
+
+  it("renders link with correct default href", () => {
+    render(<RecipeCard recipe={mockRecipe} />);
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/recipes/test-recipe");
+  });
+
+  it("renders link with custom href when provided", () => {
+    render(<RecipeCard recipe={mockRecipe} href="/custom/path" />);
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/custom/path");
+  });
+
+  it("has correct aria-label for accessibility", () => {
+    render(<RecipeCard recipe={mockRecipe} />);
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("aria-label", "View recipe: Test Recipe");
+  });
+
+  it("renders without description when not provided", () => {
+    const recipeWithoutDescription = {
+      ...mockRecipe,
+      description: "",
+    };
+    render(<RecipeCard recipe={recipeWithoutDescription} />);
+    expect(screen.getByText("Test Recipe")).toBeInTheDocument();
+    // Description paragraph should not be rendered
+    expect(
+      screen.queryByText("A delicious test recipe for unit testing")
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders without tags section when no tags", () => {
+    const recipeWithoutTags = {
+      ...mockRecipe,
+      tags: [],
+    };
+    render(<RecipeCard recipe={recipeWithoutTags} />);
+    expect(screen.queryByText("healthy")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Create reusable RecipeCard component for displaying recipe summaries
- Replace placeholder recipe list with RecipeCard component
- Add comprehensive unit tests (16 test cases)

## Changes
- **New:** `src/components/RecipeCard.tsx` - RecipeCard component with:
  - Image display with placeholder fallback (🍳 emoji)
  - Title, description (line-clamped), and tags (max 3 with +N more indicator)
  - Prep/cook time formatting and servings with proper pluralization
  - Hover state and accessibility attributes
- **New:** `src/components/__tests__/RecipeCard.test.tsx` - Unit tests
- **Modified:** `src/app/recipes/page.tsx` - Use RecipeCard component

## Test plan
- [x] ESLint passes
- [x] Production build succeeds
- [x] All unit tests pass (119 total, 16 new)
- [x] Manual testing of recipes page

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)