### PR TITLE
fix: prevent chat button overlap with bottom nav bar

### DIFF
--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -3,7 +3,9 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
-// Only show on these exact paths
+// Only show on main list pages (home and recipes)
+// Note: Auth pages (/login, /register, /onboarding) are already excluded
+// because they're not in VISIBLE_PATHS, but this is documented here for clarity
 const VISIBLE_PATHS = ['/', '/recipes'];
 
 export function BottomNav() {

--- a/src/components/ChatButton.tsx
+++ b/src/components/ChatButton.tsx
@@ -17,8 +17,9 @@ export function ChatButton() {
     pageContext
   } = useChat();
 
-  // Don't show the chat button on the onboarding page (it has its own chat)
-  if (pathname === '/onboarding') {
+  // Don't show the chat button on auth pages
+  const AUTH_PAGES = ['/login', '/register', '/onboarding'];
+  if (AUTH_PAGES.includes(pathname)) {
     return null;
   }
 
@@ -27,7 +28,7 @@ export function ChatButton() {
       {/* Hide button on desktop when sidebar is open */}
       <button
         onClick={() => openChat()}
-        className={`fixed bottom-6 right-6 bg-emerald-500 hover:bg-emerald-600 text-white rounded-full w-14 h-14 shadow-lg flex items-center justify-center z-40 transition ${
+        className={`fixed bottom-20 right-6 bg-emerald-500 hover:bg-emerald-600 text-white rounded-full w-14 h-14 shadow-lg flex items-center justify-center z-50 transition ${
           isOpen ? 'md:hidden' : ''
         }`}
         aria-label="Personal Trainer"


### PR DESCRIPTION
## Summary
- Move chat button from `bottom-6` (24px) to `bottom-20` (80px) to clear the 64px nav bar with 16px spacing
- Update z-index from `z-40` to `z-50` for proper layering
- Add auth page exclusions (`/login`, `/register`, `/onboarding`) to hide chat button on unauthenticated pages
- Add documentation comment to BottomNav explaining visibility logic

Closes #97

## Test plan
- [ ] Navigate to `/login` → verify no chat button visible
- [ ] Navigate to `/register` → verify no chat button visible
- [ ] Navigate to `/onboarding` (as new user) → verify no chat button visible
- [ ] Log in and navigate to `/` → verify chat button is visible and clickable above nav bar
- [ ] Navigate to `/recipes` → verify chat button is visible and clickable
- [ ] Click chat button → verify modal opens correctly
- [ ] Test on mobile viewport (375px) and desktop viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)