### PR TITLE
feat: add recipe versioning API endpoints

### DIFF
--- a/src/app/api/recipes/[slug]/__tests__/route.test.ts
+++ b/src/app/api/recipes/[slug]/__tests__/route.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock dependencies before importing the routes
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/recipes", () => ({
+  getRecipeBySlug: vi.fn(),
+  updateRecipe: vi.fn(),
+  deleteRecipe: vi.fn(),
+  updateRecipeInPlace: vi.fn(),
+}));
+
+import { GET, PATCH, PUT, DELETE } from "../route";
+import { auth } from "@/lib/auth";
+import {
+  getRecipeBySlug,
+  updateRecipe,
+  deleteRecipe,
+  updateRecipeInPlace,
+} from "@/lib/recipes";
+
+const mockAuth = vi.mocked(auth);
+const mockGetRecipeBySlug = vi.mocked(getRecipeBySlug);
+const mockUpdateRecipe = vi.mocked(updateRecipe);
+const mockDeleteRecipe = vi.mocked(deleteRecipe);
+const mockUpdateRecipeInPlace = vi.mocked(updateRecipeInPlace);
+
+function createRequest(method: string, body?: object): Request {
+  const options: RequestInit = {
+    method,
+    headers: { "Content-Type": "application/json" },
+  };
+  if (body) {
+    options.body = JSON.stringify(body);
+  }
+  return new Request("http://localhost/api/recipes/test-slug", options);
+}
+
+function createRouteParams(slug: string) {
+  return { params: Promise.resolve({ slug }) };
+}
+
+const mockRecipe = {
+  id: 1,
+  userId: 1,
+  slug: "test-recipe",
+  version: 1,
+  title: "Test Recipe",
+  description: "A test recipe",
+  locale: "en-US",
+  tags: ["breakfast"],
+  recipeJson: {
+    slug: "test-recipe",
+    title: "Test Recipe",
+    description: "A test recipe",
+    tags: ["breakfast"],
+    servings: 2,
+    nutrition: { calories: 100, protein: 10, carbohydrates: 20, fat: 5 },
+    ingredientGroups: [],
+    steps: [],
+    images: [{ url: "/img.jpg" }],
+    locale: "en-US",
+  },
+  isActive: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe("GET /api/recipes/[slug]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+
+    const request = createRequest("GET");
+    const response = await GET(request, createRouteParams("test-slug"));
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("returns 404 when recipe not found", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockGetRecipeBySlug.mockResolvedValue(null);
+
+    const request = createRequest("GET");
+    const response = await GET(request, createRouteParams("nonexistent"));
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error).toBe("Recipe not found");
+  });
+
+  it("returns recipe when found", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockGetRecipeBySlug.mockResolvedValue(mockRecipe);
+
+    const request = createRequest("GET");
+    const response = await GET(request, createRouteParams("test-recipe"));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.recipe.slug).toBe("test-recipe");
+  });
+
+  it("returns 500 on error", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockGetRecipeBySlug.mockRejectedValue(new Error("Database error"));
+
+    const request = createRequest("GET");
+    const response = await GET(request, createRouteParams("test-recipe"));
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe("Failed to fetch recipe");
+  });
+});
+
+describe("PATCH /api/recipes/[slug]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+
+    const request = createRequest("PATCH", { title: "Updated" });
+    const response = await PATCH(request, createRouteParams("test-slug"));
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("updates recipe and returns updated version", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockUpdateRecipe.mockResolvedValue({ ...mockRecipe, version: 2, title: "Updated Recipe" });
+
+    const request = createRequest("PATCH", { title: "Updated Recipe" });
+    const response = await PATCH(request, createRouteParams("test-recipe"));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.recipe.version).toBe(2);
+    expect(data.recipe.title).toBe("Updated Recipe");
+  });
+
+  it("returns 404 when recipe not found", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockUpdateRecipe.mockRejectedValue(new Error("Recipe not found"));
+
+    const request = createRequest("PATCH", { title: "Updated" });
+    const response = await PATCH(request, createRouteParams("nonexistent"));
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error).toBe("Recipe not found");
+  });
+
+  it("returns 500 on error", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockUpdateRecipe.mockRejectedValue(new Error("Database error"));
+
+    const request = createRequest("PATCH", { title: "Updated" });
+    const response = await PATCH(request, createRouteParams("test-recipe"));
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe("Failed to update recipe");
+  });
+});
+
+describe("PUT /api/recipes/[slug]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+
+    const request = createRequest("PUT", { title: "Updated" });
+    const response = await PUT(request, createRouteParams("test-slug"));
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("updates recipe in place and returns success", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockUpdateRecipeInPlace.mockResolvedValue({ success: true });
+
+    const request = createRequest("PUT", { title: "Updated Title" });
+    const response = await PUT(request, createRouteParams("test-recipe"));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+  });
+
+  it("returns 404 when recipe not found or inactive", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockUpdateRecipeInPlace.mockRejectedValue(new Error("Recipe not found or inactive"));
+
+    const request = createRequest("PUT", { title: "Updated" });
+    const response = await PUT(request, createRouteParams("nonexistent"));
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error).toBe("Recipe not found");
+  });
+
+  it("returns 500 on error", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockUpdateRecipeInPlace.mockRejectedValue(new Error("Database error"));
+
+    const request = createRequest("PUT", { title: "Updated" });
+    const response = await PUT(request, createRouteParams("test-recipe"));
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe("Failed to update recipe");
+  });
+});
+
+describe("DELETE /api/recipes/[slug]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+
+    const request = createRequest("DELETE");
+    const response = await DELETE(request, createRouteParams("test-slug"));
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("deletes recipe and returns success", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockDeleteRecipe.mockResolvedValue(undefined);
+
+    const request = createRequest("DELETE");
+    const response = await DELETE(request, createRouteParams("test-recipe"));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+  });
+
+  it("returns 500 on error", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockDeleteRecipe.mockRejectedValue(new Error("Database error"));
+
+    const request = createRequest("DELETE");
+    const response = await DELETE(request, createRouteParams("test-recipe"));
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe("Failed to delete recipe");
+  });
+});

--- a/src/app/api/recipes/[slug]/version/__tests__/route.test.ts
+++ b/src/app/api/recipes/[slug]/version/__tests__/route.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock dependencies before importing the routes
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/recipes", () => ({
+  saveRecipeVersion: vi.fn(),
+}));
+
+import { POST } from "../route";
+import { auth } from "@/lib/auth";
+import { saveRecipeVersion } from "@/lib/recipes";
+
+const mockAuth = vi.mocked(auth);
+const mockSaveRecipeVersion = vi.mocked(saveRecipeVersion);
+
+function createRequest(body?: object): Request {
+  const options: RequestInit = {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+  };
+  if (body) {
+    options.body = JSON.stringify(body);
+  }
+  return new Request("http://localhost/api/recipes/test-slug/version", options);
+}
+
+function createRouteParams(slug: string) {
+  return { params: Promise.resolve({ slug }) };
+}
+
+describe("POST /api/recipes/[slug]/version", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+
+    const request = createRequest({ title: "Updated Title" });
+    const response = await POST(request, createRouteParams("test-slug"));
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("creates new version and returns version number", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockSaveRecipeVersion.mockResolvedValue({ version: 2 });
+
+    const request = createRequest({ title: "Updated Title" });
+    const response = await POST(request, createRouteParams("test-recipe"));
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data).toEqual({ version: 2 });
+    expect(mockSaveRecipeVersion).toHaveBeenCalledWith("test-recipe", { title: "Updated Title" });
+  });
+
+  it("creates new version with multiple fields", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockSaveRecipeVersion.mockResolvedValue({ version: 3 });
+
+    const updateInput = {
+      title: "New Title",
+      description: "New Description",
+      tags: ["lunch", "quick"],
+    };
+    const request = createRequest(updateInput);
+    const response = await POST(request, createRouteParams("test-recipe"));
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data).toEqual({ version: 3 });
+    expect(mockSaveRecipeVersion).toHaveBeenCalledWith("test-recipe", updateInput);
+  });
+
+  it("returns 404 when recipe not found", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockSaveRecipeVersion.mockRejectedValue(new Error("Recipe not found"));
+
+    const request = createRequest({ title: "Updated" });
+    const response = await POST(request, createRouteParams("nonexistent"));
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error).toBe("Recipe not found");
+  });
+
+  it("returns 500 on error", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockSaveRecipeVersion.mockRejectedValue(new Error("Database error"));
+
+    const request = createRequest({ title: "Updated" });
+    const response = await POST(request, createRouteParams("test-recipe"));
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe("Failed to create recipe version");
+  });
+});

--- a/src/app/api/recipes/[slug]/version/route.ts
+++ b/src/app/api/recipes/[slug]/version/route.ts
@@ -1,0 +1,36 @@
+import { auth } from "@/lib/auth";
+import { saveRecipeVersion } from "@/lib/recipes";
+import { UpdateRecipeInput } from "@/lib/recipe-types";
+
+export const runtime = "nodejs";
+
+type RouteParams = { params: Promise<{ slug: string }> };
+
+/**
+ * POST /api/recipes/[slug]/version
+ * Create a new version of a recipe
+ * Returns the new version number
+ */
+export async function POST(request: Request, { params }: RouteParams) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { slug } = await params;
+    const body = await request.json() as UpdateRecipeInput;
+
+    const result = await saveRecipeVersion(slug, body);
+    return Response.json(result, { status: 201 });
+  } catch (error) {
+    console.error("Error creating recipe version:", error);
+    if (error instanceof Error && error.message === "Recipe not found") {
+      return Response.json({ error: "Recipe not found" }, { status: 404 });
+    }
+    return Response.json(
+      { error: "Failed to create recipe version" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/recipes/[slug]/versions/__tests__/route.test.ts
+++ b/src/app/api/recipes/[slug]/versions/__tests__/route.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock dependencies before importing the routes
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/recipes", () => ({
+  getRecipeVersions: vi.fn(),
+}));
+
+import { GET } from "../route";
+import { auth } from "@/lib/auth";
+import { getRecipeVersions } from "@/lib/recipes";
+
+const mockAuth = vi.mocked(auth);
+const mockGetRecipeVersions = vi.mocked(getRecipeVersions);
+
+function createRequest(queryParams?: string): Request {
+  const url = queryParams
+    ? `http://localhost/api/recipes/test-slug/versions?${queryParams}`
+    : "http://localhost/api/recipes/test-slug/versions";
+  return new Request(url, { method: "GET" });
+}
+
+function createRouteParams(slug: string) {
+  return { params: Promise.resolve({ slug }) };
+}
+
+const mockVersions = [
+  {
+    version: 3,
+    title: "Updated Title",
+    description: "Latest version",
+    createdAt: new Date("2024-01-03"),
+    isActive: true,
+  },
+  {
+    version: 2,
+    title: "Second Update",
+    description: "Second version",
+    createdAt: new Date("2024-01-02"),
+    isActive: false,
+  },
+  {
+    version: 1,
+    title: "Original Title",
+    description: "First version",
+    createdAt: new Date("2024-01-01"),
+    isActive: false,
+  },
+];
+
+describe("GET /api/recipes/[slug]/versions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+
+    const request = createRequest();
+    const response = await GET(request, createRouteParams("test-slug"));
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("returns all versions for a recipe", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockGetRecipeVersions.mockResolvedValue(mockVersions);
+
+    const request = createRequest();
+    const response = await GET(request, createRouteParams("test-recipe"));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.versions).toHaveLength(3);
+    expect(data.versions[0].version).toBe(3);
+    expect(data.versions[0].isActive).toBe(true);
+    expect(mockGetRecipeVersions).toHaveBeenCalledWith("test-recipe", {});
+  });
+
+  it("returns empty array when no versions exist", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockGetRecipeVersions.mockResolvedValue([]);
+
+    const request = createRequest();
+    const response = await GET(request, createRouteParams("nonexistent"));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.versions).toEqual([]);
+  });
+
+  it("supports limit query parameter", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockGetRecipeVersions.mockResolvedValue(mockVersions.slice(0, 2));
+
+    const request = createRequest("limit=2");
+    const response = await GET(request, createRouteParams("test-recipe"));
+
+    expect(response.status).toBe(200);
+    expect(mockGetRecipeVersions).toHaveBeenCalledWith("test-recipe", { limit: 2 });
+  });
+
+  it("supports offset query parameter", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockGetRecipeVersions.mockResolvedValue(mockVersions.slice(1));
+
+    const request = createRequest("offset=1");
+    const response = await GET(request, createRouteParams("test-recipe"));
+
+    expect(response.status).toBe(200);
+    expect(mockGetRecipeVersions).toHaveBeenCalledWith("test-recipe", { offset: 1 });
+  });
+
+  it("supports both limit and offset query parameters", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockGetRecipeVersions.mockResolvedValue([mockVersions[1]]);
+
+    const request = createRequest("limit=1&offset=1");
+    const response = await GET(request, createRouteParams("test-recipe"));
+
+    expect(response.status).toBe(200);
+    expect(mockGetRecipeVersions).toHaveBeenCalledWith("test-recipe", { limit: 1, offset: 1 });
+  });
+
+  it("ignores invalid limit parameter", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockGetRecipeVersions.mockResolvedValue(mockVersions);
+
+    const request = createRequest("limit=invalid");
+    const response = await GET(request, createRouteParams("test-recipe"));
+
+    expect(response.status).toBe(200);
+    expect(mockGetRecipeVersions).toHaveBeenCalledWith("test-recipe", {});
+  });
+
+  it("ignores negative limit parameter", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockGetRecipeVersions.mockResolvedValue(mockVersions);
+
+    const request = createRequest("limit=-5");
+    const response = await GET(request, createRouteParams("test-recipe"));
+
+    expect(response.status).toBe(200);
+    expect(mockGetRecipeVersions).toHaveBeenCalledWith("test-recipe", {});
+  });
+
+  it("ignores negative offset parameter", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockGetRecipeVersions.mockResolvedValue(mockVersions);
+
+    const request = createRequest("offset=-1");
+    const response = await GET(request, createRouteParams("test-recipe"));
+
+    expect(response.status).toBe(200);
+    expect(mockGetRecipeVersions).toHaveBeenCalledWith("test-recipe", {});
+  });
+
+  it("allows offset of 0", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockGetRecipeVersions.mockResolvedValue(mockVersions);
+
+    const request = createRequest("offset=0");
+    const response = await GET(request, createRouteParams("test-recipe"));
+
+    expect(response.status).toBe(200);
+    expect(mockGetRecipeVersions).toHaveBeenCalledWith("test-recipe", { offset: 0 });
+  });
+
+  it("returns 500 on error", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockGetRecipeVersions.mockRejectedValue(new Error("Database error"));
+
+    const request = createRequest();
+    const response = await GET(request, createRouteParams("test-recipe"));
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe("Failed to fetch recipe versions");
+  });
+});

--- a/src/app/api/recipes/[slug]/versions/route.ts
+++ b/src/app/api/recipes/[slug]/versions/route.ts
@@ -1,0 +1,50 @@
+import { auth } from "@/lib/auth";
+import { getRecipeVersions } from "@/lib/recipes";
+
+export const runtime = "nodejs";
+
+type RouteParams = { params: Promise<{ slug: string }> };
+
+/**
+ * GET /api/recipes/[slug]/versions
+ * Get version history for a recipe
+ * Supports pagination via ?limit=N&offset=M query params
+ */
+export async function GET(request: Request, { params }: RouteParams) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { slug } = await params;
+
+    // Parse optional pagination query params
+    const url = new URL(request.url);
+    const limitParam = url.searchParams.get("limit");
+    const offsetParam = url.searchParams.get("offset");
+
+    const options: { limit?: number; offset?: number } = {};
+    if (limitParam !== null) {
+      const limit = parseInt(limitParam, 10);
+      if (!isNaN(limit) && limit > 0) {
+        options.limit = limit;
+      }
+    }
+    if (offsetParam !== null) {
+      const offset = parseInt(offsetParam, 10);
+      if (!isNaN(offset) && offset >= 0) {
+        options.offset = offset;
+      }
+    }
+
+    const versions = await getRecipeVersions(slug, options);
+    return Response.json({ versions });
+  } catch (error) {
+    console.error("Error fetching recipe versions:", error);
+    return Response.json(
+      { error: "Failed to fetch recipe versions" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/recipes/__tests__/route.test.ts
+++ b/src/app/api/recipes/__tests__/route.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock dependencies before importing the routes
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/recipes", () => ({
+  getUserRecipeSummaries: vi.fn(),
+  createRecipe: vi.fn(),
+}));
+
+import { GET, POST } from "../route";
+import { auth } from "@/lib/auth";
+import { getUserRecipeSummaries, createRecipe } from "@/lib/recipes";
+
+const mockAuth = vi.mocked(auth);
+const mockGetUserRecipeSummaries = vi.mocked(getUserRecipeSummaries);
+const mockCreateRecipe = vi.mocked(createRecipe);
+
+function createRequest(method: string, body?: object): Request {
+  const options: RequestInit = {
+    method,
+    headers: { "Content-Type": "application/json" },
+  };
+  if (body) {
+    options.body = JSON.stringify(body);
+  }
+  return new Request("http://localhost/api/recipes", options);
+}
+
+describe("GET /api/recipes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("returns recipes for authenticated user", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockGetUserRecipeSummaries.mockResolvedValue([
+      {
+        slug: "test-recipe",
+        title: "Test Recipe",
+        description: "A test",
+        tags: ["breakfast"],
+        servings: 2,
+        nutrition: { calories: 100, protein: 10, carbohydrates: 20, fat: 5 },
+      },
+    ]);
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.recipes).toHaveLength(1);
+    expect(data.recipes[0].slug).toBe("test-recipe");
+  });
+
+  it("returns 500 on error", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockGetUserRecipeSummaries.mockRejectedValue(new Error("Database error"));
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe("Failed to fetch recipes");
+  });
+});
+
+describe("POST /api/recipes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const validRecipeInput = {
+    title: "New Recipe",
+    recipeJson: {
+      slug: "new-recipe",
+      title: "New Recipe",
+      description: "A new recipe",
+      tags: ["dinner"],
+      servings: 4,
+      nutrition: { calories: 400, protein: 30, carbohydrates: 40, fat: 15 },
+      ingredientGroups: [],
+      steps: [],
+      images: [{ url: "/img.jpg" }],
+      locale: "en-US",
+    },
+  };
+
+  it("returns 401 when not authenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+
+    const request = createRequest("POST", validRecipeInput);
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("returns 400 when title is missing", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+
+    const request = createRequest("POST", { recipeJson: validRecipeInput.recipeJson });
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe("Missing required fields: title and recipeJson");
+  });
+
+  it("returns 400 when recipeJson is missing", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+
+    const request = createRequest("POST", { title: "Test" });
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe("Missing required fields: title and recipeJson");
+  });
+
+  it("creates recipe and returns slug and version", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockCreateRecipe.mockResolvedValue({
+      id: 1,
+      userId: 1,
+      slug: "new-recipe",
+      version: 1,
+      title: "New Recipe",
+      description: null,
+      locale: "en-US",
+      tags: ["dinner"],
+      recipeJson: validRecipeInput.recipeJson,
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const request = createRequest("POST", validRecipeInput);
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data).toEqual({ slug: "new-recipe", version: 1 });
+  });
+
+  it("returns 500 on error", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockCreateRecipe.mockRejectedValue(new Error("Database error"));
+
+    const request = createRequest("POST", validRecipeInput);
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe("Failed to create recipe");
+  });
+});

--- a/src/app/api/recipes/route.ts
+++ b/src/app/api/recipes/route.ts
@@ -47,7 +47,7 @@ export async function POST(request: Request) {
     }
 
     const recipe = await createRecipe(body);
-    return Response.json({ recipe }, { status: 201 });
+    return Response.json({ slug: recipe.slug, version: recipe.version }, { status: 201 });
   } catch (error) {
     console.error("Error creating recipe:", error);
     return Response.json(


### PR DESCRIPTION
## Summary
- Add PUT `/api/recipes/[slug]` for in-place recipe updates (without creating new version)
- Add POST `/api/recipes/[slug]/version` to create new recipe versions
- Add GET `/api/recipes/[slug]/versions` to retrieve version history with pagination
- Change POST `/api/recipes` response format from `{ recipe }` to `{ slug, version }`

Closes #59

## Test plan
- [x] Unit tests for all new endpoints (39 new tests)
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] `npm run test:unit` passes (165 total tests)

🤖 Generated with [Claude Code](https://claude.ai/code)