### PR TITLE
refactor: deduplicate generateImageId function

### DIFF
--- a/src/app/api/recipes/images/upload/route.ts
+++ b/src/app/api/recipes/images/upload/route.ts
@@ -6,6 +6,7 @@
  */
 
 import { auth } from "@/lib/auth";
+import { generateImageId } from "@/lib/image-utils";
 import { saveRecipeImage, getRecipeImageUrl } from "@/lib/recipe-image-storage";
 
 export const runtime = "nodejs";
@@ -138,12 +139,4 @@ export async function POST(request: Request) {
       { status: 500 }
     );
   }
-}
-
-/**
- * Generate a unique image ID using cryptographically secure random values
- */
-function generateImageId(): string {
-  // Use crypto.randomUUID() for robust, collision-resistant ID generation
-  return crypto.randomUUID();
 }


### PR DESCRIPTION
## Summary
- Remove duplicate `generateImageId()` function from recipe image upload route
- Import the function from `@/lib/image-utils` instead
- Both implementations were identical (`crypto.randomUUID()`)

Closes #105

## Test plan
- [x] Lint passes (no new errors)
- [x] Build succeeds
- [x] All 421 unit tests pass
- [x] Manual testing: Image upload in recipe form works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)