### PR TITLE
fix: prevent scrollbar layout shift on page navigation

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,6 +5,13 @@
   --foreground: #f8fafc;
 }
 
+html {
+  overflow-y: scroll;
+  /* Firefox scrollbar styling */
+  scrollbar-width: thin;
+  scrollbar-color: #334155 var(--background);
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -23,6 +30,24 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: var(--font-geist-sans), ui-sans-serif, system-ui;
+}
+
+/* Custom scrollbar styling for WebKit browsers (Chrome, Safari, Edge) */
+::-webkit-scrollbar {
+  width: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--background);
+}
+
+::-webkit-scrollbar-thumb {
+  background: #334155; /* slate-700 */
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #475569; /* slate-600 */
 }
 
 /* Prevent text selection on button elements to avoid accidental highlighting on mobile */


### PR DESCRIPTION
## Summary
- Add `overflow-y: scroll` on `html` element to always show scrollbar track
- Add Firefox scrollbar styling (`scrollbar-width: thin`, `scrollbar-color`)
- Add WebKit scrollbar styling for Chrome/Safari/Edge (8px width, slate-700/600 colors)
- Scrollbar colors blend with dark theme using CSS variables

Closes #114

## Test plan
- [x] Lint passes (0 errors)
- [x] Build succeeds
- [x] Playwright MCP: Verified scrollbar visible on login page (short content)
- [x] Playwright MCP: Verified scrollbar visible on home page (long content)
- [x] No layout shift when navigating between pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)