### PR TITLE
fix: remove double URL encoding in exercise images

### DIFF
--- a/src/components/ExerciseImages.tsx
+++ b/src/components/ExerciseImages.tsx
@@ -28,8 +28,7 @@ export function ExerciseImages({
   const [loadError, setLoadError] = useState<Record<number, boolean>>({});
   const [isLoading, setIsLoading] = useState<Record<number, boolean>>({ 1: true, 2: true });
 
-  const encodedName = encodeURIComponent(exerciseName);
-  const imageUrl = (index: 1 | 2) => `/api/exercises/${encodedName}/images/${index}`;
+  const imageUrl = (index: 1 | 2) => `/api/exercises/${exerciseName}/images/${index}`;
 
   // If both images failed to load, show nothing
   if (loadError[1] && loadError[2]) {
@@ -118,8 +117,7 @@ export function ExerciseImageThumbnail({
   const [hasError, setHasError] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
-  const encodedName = encodeURIComponent(exerciseName);
-  const imageUrl = `/api/exercises/${encodedName}/images/1`;
+  const imageUrl = `/api/exercises/${exerciseName}/images/1`;
 
   if (hasError) {
     return null;


### PR DESCRIPTION
## Summary
- Removes `encodeURIComponent()` calls from `ExerciseImages` and `ExerciseImageThumbnail` components
- Fixes 400 Bad Request errors caused by double URL encoding (e.g., `%20` becoming `%2520`)

## Root Cause
The double encoding occurred because:
1. Component called `encodeURIComponent(exerciseName)` → `/api/exercises/Arm%20circles/images/1`
2. Next.js Image component passed this to `/_next/image?url=...` which encoded again
3. Result: `%20` became `%2520`, causing 400 errors

## Solution
Removed manual `encodeURIComponent()` since Next.js handles URL encoding automatically.

## Test plan
- [x] Lint passes (0 errors)
- [x] Build succeeds
- [x] All 519 unit tests pass
- [x] Manual testing confirmed URLs now use single encoding (`Arm%20circles` not `Arm%2520circles`)

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)