### PR TITLE
fix: persist onboardingCompleted flag in JWT after onboarding completion

### DIFF
--- a/src/lib/__tests__/auth-callbacks.test.ts
+++ b/src/lib/__tests__/auth-callbacks.test.ts
@@ -32,6 +32,9 @@ describe('Auth JWT Callback Behavior', () => {
         if (userData.unitSystem !== undefined) {
           existingToken.unitSystem = userData.unitSystem
         }
+        if (userData.onboardingCompleted !== undefined) {
+          existingToken.onboardingCompleted = userData.onboardingCompleted
+        }
       }
       return existingToken
     }
@@ -117,13 +120,13 @@ describe('Auth JWT Callback Behavior', () => {
       expect(result.timezone).toBe('America/New_York')
     })
 
-    it('does not allow modification of onboardingCompleted field (security)', () => {
+    it('allows modification of onboardingCompleted field via session update', () => {
       const token = { id: '1', timezone: 'UTC', locale: 'en-US', unitSystem: 'metric', onboardingCompleted: false }
       const session = { user: { onboardingCompleted: true, timezone: 'Europe/Berlin' } }
 
       const result = simulateJwtCallbackUpdate(token, session)
 
-      expect(result.onboardingCompleted).toBe(false) // should not change
+      expect(result.onboardingCompleted).toBe(true) // should change now
       expect(result.timezone).toBe('Europe/Berlin')
     })
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -88,7 +88,7 @@ export const { handlers, auth, signIn, signOut, unstable_update } = NextAuth({
       // Session update triggered - merge new preferences into token
       // Only update specific preference fields (security: prevent arbitrary token modification)
       if (trigger === "update" && session?.user) {
-        const userData = session.user as { timezone?: string; locale?: string; unitSystem?: UnitSystem };
+        const userData = session.user as { timezone?: string; locale?: string; unitSystem?: UnitSystem; onboardingCompleted?: boolean };
         if (userData.timezone !== undefined) {
           token.timezone = userData.timezone;
         }
@@ -97,6 +97,9 @@ export const { handlers, auth, signIn, signOut, unstable_update } = NextAuth({
         }
         if (userData.unitSystem !== undefined) {
           token.unitSystem = userData.unitSystem;
+        }
+        if (userData.onboardingCompleted !== undefined) {
+          token.onboardingCompleted = userData.onboardingCompleted;
         }
       }
 

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -11,6 +11,7 @@ declare module "next-auth" {
       timezone: string;
       locale: string;
       unitSystem: UnitSystem;
+      onboardingCompleted?: boolean;
     };
   }
 


### PR DESCRIPTION
## Summary
- Add `onboardingCompleted` to allowed JWT update fields in `auth.ts`
- Call `unstable_update` after DB update in onboarding route to refresh the JWT token
- Update unit tests to reflect new behavior where `onboardingCompleted` can be updated via session update
- Add `onboardingCompleted` to Session user type definition

## Root Cause
When a user completed onboarding, the `onboarding_completed` field was updated in the database but the JWT token was never refreshed. This caused the app to incorrectly redirect users back to `/onboarding` after a page refresh because the JWT still had `onboardingCompleted: false`.

## Solution
Follow the pattern established in PR #141 for user preferences:
1. Add `onboardingCompleted` to the allowed fields in the JWT callback's update trigger
2. Call `unstable_update` in the onboarding API route after the DB update succeeds

Closes #142

## Test plan
- [x] All 533 unit tests pass
- [x] Lint passes (no new errors)
- [x] Build succeeds
- [x] Manual testing: User stays on home page after page refresh (not redirected to onboarding)

🤖 Generated with [Claude Code](https://claude.ai/code)