### PR TITLE
feat: add chat history UI component to browse past conversations

### DIFF
--- a/e2e/chat-history.spec.ts
+++ b/e2e/chat-history.spec.ts
@@ -1,0 +1,143 @@
+import { test, expect } from './fixtures/auth.fixture'
+
+test.describe('Chat History', () => {
+  test.describe('History Button', () => {
+    test('shows history button in chat modal header', async ({ authenticatedPage: page }) => {
+      // Open chat modal by clicking the chat button
+      const chatButton = page.locator('[title="Personal Trainer"]').or(page.locator('button').filter({ hasText: '💬' }))
+      await chatButton.click()
+
+      // Wait for modal to open
+      await expect(page.getByText('Personal Trainer')).toBeVisible()
+
+      // History button should be visible
+      await expect(page.getByRole('button', { name: /history/i })).toBeVisible()
+    })
+
+    test('opens history panel when history button is clicked', async ({ authenticatedPage: page }) => {
+      // Open chat modal
+      const chatButton = page.locator('[title="Personal Trainer"]').or(page.locator('button').filter({ hasText: '💬' }))
+      await chatButton.click()
+      await expect(page.getByText('Personal Trainer')).toBeVisible()
+
+      // Click history button
+      await page.getByRole('button', { name: /history/i }).click()
+
+      // History panel should be visible
+      await expect(page.getByText('Chat History')).toBeVisible()
+    })
+  })
+
+  test.describe('Empty State', () => {
+    test('shows empty state for new users with no chat history', async ({ authenticatedPage: page }) => {
+      // Open chat modal
+      const chatButton = page.locator('[title="Personal Trainer"]').or(page.locator('button').filter({ hasText: '💬' }))
+      await chatButton.click()
+      await expect(page.getByText('Personal Trainer')).toBeVisible()
+
+      // Click history button
+      await page.getByRole('button', { name: /history/i }).click()
+
+      // Wait for history panel
+      await expect(page.getByText('Chat History')).toBeVisible()
+
+      // Should show empty state
+      await expect(page.getByText('No conversations yet')).toBeVisible()
+      await expect(page.getByText('Start chatting to see your history here.')).toBeVisible()
+    })
+  })
+
+  test.describe('Close Functionality', () => {
+    test('closes history panel when close button is clicked', async ({ authenticatedPage: page }) => {
+      // Open chat modal
+      const chatButton = page.locator('[title="Personal Trainer"]').or(page.locator('button').filter({ hasText: '💬' }))
+      await chatButton.click()
+      await expect(page.getByText('Personal Trainer')).toBeVisible()
+
+      // Open history
+      await page.getByRole('button', { name: /history/i }).click()
+      await expect(page.getByText('Chat History')).toBeVisible()
+
+      // Close history panel
+      await page.getByLabel('Close history').click()
+
+      // History panel should be hidden
+      await expect(page.getByText('Chat History')).not.toBeVisible()
+
+      // Chat modal should still be visible
+      await expect(page.getByText('Personal Trainer')).toBeVisible()
+    })
+  })
+
+  test.describe('Chat Session Creation and History', () => {
+    test('creates a chat session when user sends a message', async ({ authenticatedPage: page }) => {
+      // Open chat modal
+      const chatButton = page.locator('[title="Personal Trainer"]').or(page.locator('button').filter({ hasText: '💬' }))
+      await chatButton.click()
+      await expect(page.getByText('Personal Trainer')).toBeVisible()
+
+      // Send a message
+      const textarea = page.locator('textarea[placeholder*="Type a message"]')
+      await textarea.fill('Hello, I want to improve my workout routine.')
+      await page.getByRole('button', { name: 'Send' }).click()
+
+      // Wait for AI response (may take a while)
+      await expect(page.locator('.bg-slate-800').first()).toBeVisible({ timeout: 30000 })
+
+      // Close chat modal
+      await page.getByLabel('Close').click()
+
+      // Reopen chat modal
+      await chatButton.click()
+      await expect(page.getByText('Personal Trainer')).toBeVisible()
+
+      // Open history
+      await page.getByRole('button', { name: /history/i }).click()
+      await expect(page.getByText('Chat History')).toBeVisible()
+
+      // Should now show at least one session
+      await expect(page.getByText('No conversations yet')).not.toBeVisible({ timeout: 5000 })
+
+      // Should show the session with our message as preview
+      await expect(page.getByText(/Hello, I want to improve/i)).toBeVisible()
+    })
+
+    test('loads previous session when clicking on it in history', async ({ authenticatedPage: page }) => {
+      // First, create a chat session with a unique message
+      const testMessage = `Test message ${Date.now()}`
+
+      // Open chat modal
+      const chatButton = page.locator('[title="Personal Trainer"]').or(page.locator('button').filter({ hasText: '💬' }))
+      await chatButton.click()
+      await expect(page.getByText('Personal Trainer')).toBeVisible()
+
+      // Send a message
+      const textarea = page.locator('textarea[placeholder*="Type a message"]')
+      await textarea.fill(testMessage)
+      await page.getByRole('button', { name: 'Send' }).click()
+
+      // Wait for AI response
+      await expect(page.locator('.bg-slate-800').first()).toBeVisible({ timeout: 30000 })
+
+      // Start a new chat
+      await page.getByRole('button', { name: /new chat/i }).click()
+
+      // The messages should be cleared
+      await expect(page.getByText(testMessage)).not.toBeVisible()
+
+      // Open history
+      await page.getByRole('button', { name: /history/i }).click()
+      await expect(page.getByText('Chat History')).toBeVisible()
+
+      // Click on the previous session (first in the list as it's the most recent)
+      const sessionButton = page.locator('button').filter({ hasText: testMessage.substring(0, 30) }).first()
+      await sessionButton.click()
+
+      // History panel should close
+      await expect(page.getByText('Chat History')).not.toBeVisible()
+
+      // The messages from the previous session should be loaded
+      await expect(page.getByText(testMessage)).toBeVisible()
+    })
+  })
+})

--- a/src/app/api/chat/sessions/__tests__/route.test.ts
+++ b/src/app/api/chat/sessions/__tests__/route.test.ts
@@ -1,0 +1,338 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock dependencies before importing the route
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  query: vi.fn(),
+}));
+
+import { GET } from "../route";
+import { auth } from "@/lib/auth";
+import { query } from "@/lib/db";
+
+const mockAuth = vi.mocked(auth);
+const mockQuery = vi.mocked(query);
+
+function createRequest(params: Record<string, string> = {}): Request {
+  const url = new URL("http://localhost/api/chat/sessions");
+  Object.entries(params).forEach(([key, value]) => {
+    url.searchParams.set(key, value);
+  });
+  return new Request(url.toString(), { method: "GET" });
+}
+
+const mockSessions = [
+  {
+    id: 3,
+    title: "Workout modification help",
+    created_at: new Date("2024-01-17T10:00:00Z"),
+    preview: "How can I modify the Monday workout?",
+    message_count: 8,
+  },
+  {
+    id: 2,
+    title: null,
+    created_at: new Date("2024-01-16T15:30:00Z"),
+    preview: "What exercises help with back pain?",
+    message_count: 4,
+  },
+  {
+    id: 1,
+    title: "Getting started",
+    created_at: new Date("2024-01-15T09:00:00Z"),
+    preview: null,
+    message_count: 0,
+  },
+];
+
+describe("GET /api/chat/sessions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+
+    const request = createRequest();
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("returns 401 when user id is missing", async () => {
+    mockAuth.mockResolvedValue({
+      user: { email: "test@example.com" },
+      expires: new Date().toISOString(),
+    } as ReturnType<typeof auth> extends Promise<infer T> ? T : never);
+
+    const request = createRequest();
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("returns empty array when user has no sessions", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const request = createRequest();
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.sessions).toEqual([]);
+    expect(data.hasMore).toBe(false);
+    expect(data.nextCursor).toBeNull();
+  });
+
+  it("returns sessions ordered by creation date (newest first)", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockQuery.mockResolvedValueOnce({ rows: mockSessions, rowCount: mockSessions.length });
+
+    const request = createRequest();
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.sessions).toHaveLength(3);
+    expect(data.sessions[0].id).toBe(3);
+    expect(data.sessions[1].id).toBe(2);
+    expect(data.sessions[2].id).toBe(1);
+  });
+
+  it("includes preview from first user message", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockQuery.mockResolvedValueOnce({ rows: mockSessions, rowCount: mockSessions.length });
+
+    const request = createRequest();
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.sessions[0].preview).toBe("How can I modify the Monday workout?");
+    expect(data.sessions[2].preview).toBeNull();
+  });
+
+  it("includes message count", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockQuery.mockResolvedValueOnce({ rows: mockSessions, rowCount: mockSessions.length });
+
+    const request = createRequest();
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.sessions[0].messageCount).toBe(8);
+    expect(data.sessions[1].messageCount).toBe(4);
+    expect(data.sessions[2].messageCount).toBe(0);
+  });
+
+  it("handles sessions with null title", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockQuery.mockResolvedValueOnce({ rows: mockSessions, rowCount: mockSessions.length });
+
+    const request = createRequest();
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.sessions[1].title).toBeNull();
+  });
+
+  it("respects default pagination limit of 20", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const request = createRequest();
+    await GET(request);
+
+    // Verify query was called with limit of 21 (20 + 1 to check hasMore)
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("LIMIT $2"),
+      ["1", 21]
+    );
+  });
+
+  it("respects custom pagination limit", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const request = createRequest({ limit: "10" });
+    await GET(request);
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("LIMIT $2"),
+      ["1", 11]
+    );
+  });
+
+  it("caps pagination limit at 50", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const request = createRequest({ limit: "100" });
+    await GET(request);
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("LIMIT $2"),
+      ["1", 51]
+    );
+  });
+
+  it("handles cursor-based pagination", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockQuery.mockResolvedValueOnce({ rows: [mockSessions[2]], rowCount: 1 });
+
+    const request = createRequest({ cursor: "2" });
+    await GET(request);
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("AND cs.id < $3"),
+      ["1", 21, "2"]
+    );
+  });
+
+  it("returns hasMore true and nextCursor when more results exist", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+
+    // Return 21 results (one more than limit of 20)
+    const manyResults = Array.from({ length: 21 }, (_, i) => ({
+      id: 100 - i,
+      title: `Session ${100 - i}`,
+      created_at: new Date(),
+      preview: null,
+      message_count: i,
+    }));
+    mockQuery.mockResolvedValueOnce({ rows: manyResults, rowCount: manyResults.length });
+
+    const request = createRequest();
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.sessions).toHaveLength(20);
+    expect(data.hasMore).toBe(true);
+    expect(data.nextCursor).toBe(81); // Last item's id in the returned page
+  });
+
+  it("returns hasMore false when no more results", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockQuery.mockResolvedValueOnce({ rows: mockSessions, rowCount: mockSessions.length });
+
+    const request = createRequest();
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.hasMore).toBe(false);
+    expect(data.nextCursor).toBeNull();
+  });
+
+  it("returns 500 on database error", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockQuery.mockRejectedValue(new Error("Database connection failed"));
+
+    const request = createRequest();
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe("Failed to fetch chat sessions");
+  });
+
+  it("verifies SQL query selects correct fields with subqueries", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "1", email: "test@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const request = createRequest();
+    await GET(request);
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("cs.id"),
+      expect.any(Array)
+    );
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("cs.title"),
+      expect.any(Array)
+    );
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("cs.created_at"),
+      expect.any(Array)
+    );
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("SUBSTRING"),
+      expect.any(Array)
+    );
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("COUNT(*)"),
+      expect.any(Array)
+    );
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("ORDER BY cs.created_at DESC"),
+      expect.any(Array)
+    );
+  });
+
+  it("only returns sessions belonging to the authenticated user", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "5", email: "user5@example.com" },
+      expires: new Date().toISOString(),
+    });
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const request = createRequest();
+    await GET(request);
+
+    // Verify query is filtered by user_id
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("WHERE cs.user_id = $1"),
+      expect.arrayContaining(["5"])
+    );
+  });
+});

--- a/src/app/api/chat/sessions/route.ts
+++ b/src/app/api/chat/sessions/route.ts
@@ -1,0 +1,78 @@
+import { auth } from "@/lib/auth";
+import { query } from "@/lib/db";
+
+export const runtime = 'nodejs';
+
+/**
+ * GET /api/chat/sessions
+ * Get a paginated list of chat sessions for the authenticated user
+ */
+export async function GET(request: Request) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const url = new URL(request.url);
+    const cursor = url.searchParams.get('cursor');
+    const limit = Math.min(parseInt(url.searchParams.get('limit') || '20', 10), 50);
+    const userId = session.user.id;
+
+    // Build query with optional cursor-based pagination
+    // Get sessions with the first user message as preview and message count
+    const sessionsQuery = `
+      SELECT
+        cs.id,
+        cs.title,
+        cs.created_at,
+        (
+          SELECT SUBSTRING(cm.content, 1, 100)
+          FROM chat_messages cm
+          WHERE cm.session_id = cs.id AND cm.role = 'user'
+          ORDER BY cm.created_at ASC
+          LIMIT 1
+        ) as preview,
+        (
+          SELECT COUNT(*)::int
+          FROM chat_messages cm
+          WHERE cm.session_id = cs.id
+        ) as message_count
+      FROM chat_sessions cs
+      WHERE cs.user_id = $1
+        ${cursor ? 'AND cs.id < $3' : ''}
+      ORDER BY cs.created_at DESC
+      LIMIT $2
+    `;
+
+    const params = cursor ? [userId, limit + 1, cursor] : [userId, limit + 1];
+    const result = await query(sessionsQuery, params);
+
+    // Check if there are more results
+    const hasMore = result.rows.length > limit;
+    const sessions = hasMore ? result.rows.slice(0, limit) : result.rows;
+
+    // Get the next cursor (last session id in this page)
+    const nextCursor = hasMore && sessions.length > 0
+      ? sessions[sessions.length - 1].id
+      : null;
+
+    return Response.json({
+      sessions: sessions.map(s => ({
+        id: s.id,
+        title: s.title,
+        createdAt: s.created_at,
+        preview: s.preview,
+        messageCount: s.message_count
+      })),
+      hasMore,
+      nextCursor
+    });
+  } catch (error) {
+    console.error("Error fetching chat sessions:", error);
+    return Response.json(
+      { error: "Failed to fetch chat sessions" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/ChatHistory.tsx
+++ b/src/components/ChatHistory.tsx
@@ -1,0 +1,226 @@
+'use client';
+import { useState, useEffect, useCallback } from 'react';
+
+interface ChatSession {
+  id: number;
+  title: string | null;
+  createdAt: string;
+  preview: string | null;
+  messageCount: number;
+}
+
+interface ChatHistoryProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelectSession: (sessionId: number) => void;
+  currentSessionId: number | null;
+}
+
+export function ChatHistory({
+  isOpen,
+  onClose,
+  onSelectSession,
+  currentSessionId
+}: ChatHistoryProps) {
+  const [sessions, setSessions] = useState<ChatSession[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(false);
+  const [nextCursor, setNextCursor] = useState<number | null>(null);
+
+  const fetchSessions = useCallback(async (cursor?: number) => {
+    try {
+      const isLoadMore = cursor !== undefined;
+      if (isLoadMore) {
+        setLoadingMore(true);
+      } else {
+        setLoading(true);
+      }
+      setError(null);
+
+      const url = cursor
+        ? `/api/chat/sessions?cursor=${cursor}`
+        : '/api/chat/sessions';
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        throw new Error('Failed to load chat history');
+      }
+
+      const data = await response.json();
+
+      if (isLoadMore) {
+        setSessions(prev => [...prev, ...data.sessions]);
+      } else {
+        setSessions(data.sessions);
+      }
+      setHasMore(data.hasMore);
+      setNextCursor(data.nextCursor);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setLoading(false);
+      setLoadingMore(false);
+    }
+  }, []);
+
+  // Fetch sessions when panel opens
+  useEffect(() => {
+    if (isOpen) {
+      fetchSessions();
+    }
+  }, [isOpen, fetchSessions]);
+
+  // Reset state when panel closes
+  useEffect(() => {
+    if (!isOpen) {
+      setSessions([]);
+      setNextCursor(null);
+      setHasMore(false);
+      setError(null);
+    }
+  }, [isOpen]);
+
+  const handleLoadMore = () => {
+    if (nextCursor && !loadingMore) {
+      fetchSessions(nextCursor);
+    }
+  };
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+    if (diffDays === 0) {
+      return 'Today';
+    } else if (diffDays === 1) {
+      return 'Yesterday';
+    } else if (diffDays < 7) {
+      return `${diffDays} days ago`;
+    } else {
+      return date.toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined
+      });
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/50 z-[60]"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      {/* Panel */}
+      <div
+        className="fixed z-[70] bg-slate-900 flex flex-col transition-all duration-300 ease-in-out
+          inset-x-0 bottom-0 rounded-t-lg h-[70vh]
+          md:inset-x-auto md:inset-y-0 md:right-[400px] md:w-[320px] md:h-screen md:rounded-none md:border-l md:border-slate-700"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-slate-700">
+          <h2 className="text-lg font-semibold">Chat History</h2>
+          <button
+            onClick={onClose}
+            className="text-slate-400 hover:text-white text-2xl leading-none"
+            aria-label="Close history"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto scrollbar-hide" style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}>
+          {/* Loading state */}
+          {loading && (
+            <div className="flex items-center justify-center py-12">
+              <div className="flex space-x-2">
+                <div className="w-2 h-2 bg-slate-400 rounded-full animate-bounce" style={{ animationDelay: '0ms' }}></div>
+                <div className="w-2 h-2 bg-slate-400 rounded-full animate-bounce" style={{ animationDelay: '150ms' }}></div>
+                <div className="w-2 h-2 bg-slate-400 rounded-full animate-bounce" style={{ animationDelay: '300ms' }}></div>
+              </div>
+            </div>
+          )}
+
+          {/* Error state */}
+          {error && !loading && (
+            <div className="p-4 text-center">
+              <p className="text-red-400 mb-4">{error}</p>
+              <button
+                onClick={() => fetchSessions()}
+                className="px-4 py-2 bg-slate-700 hover:bg-slate-600 rounded text-sm transition"
+              >
+                Try Again
+              </button>
+            </div>
+          )}
+
+          {/* Empty state */}
+          {!loading && !error && sessions.length === 0 && (
+            <div className="p-8 text-center text-slate-400">
+              <p className="text-lg mb-2">No conversations yet</p>
+              <p className="text-sm">
+                Start chatting to see your history here.
+              </p>
+            </div>
+          )}
+
+          {/* Session list */}
+          {!loading && !error && sessions.length > 0 && (
+            <div className="divide-y divide-slate-700/50">
+              {sessions.map((session) => (
+                <button
+                  key={session.id}
+                  onClick={() => onSelectSession(session.id)}
+                  className={`w-full text-left p-4 hover:bg-slate-800 transition ${
+                    currentSessionId === session.id ? 'bg-slate-800 border-l-2 border-emerald-500' : ''
+                  }`}
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0 flex-1">
+                      <h3 className="font-medium text-white truncate">
+                        {session.title || 'New Chat'}
+                      </h3>
+                      <p className="text-xs text-slate-400 mt-0.5">
+                        {formatDate(session.createdAt)} • {session.messageCount} {session.messageCount === 1 ? 'message' : 'messages'}
+                      </p>
+                      {session.preview && (
+                        <p className="text-sm text-slate-500 mt-1 line-clamp-2">
+                          &quot;{session.preview}{session.preview.length >= 100 ? '...' : ''}&quot;
+                        </p>
+                      )}
+                    </div>
+                    {currentSessionId === session.id && (
+                      <span className="text-xs text-emerald-400 whitespace-nowrap">Current</span>
+                    )}
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+
+          {/* Load more button */}
+          {hasMore && !loading && (
+            <div className="p-4 text-center">
+              <button
+                onClick={handleLoadMore}
+                disabled={loadingMore}
+                className="px-4 py-2 bg-slate-700 hover:bg-slate-600 disabled:opacity-50 rounded text-sm transition"
+              >
+                {loadingMore ? 'Loading...' : 'Load More'}
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/__tests__/ChatHistory.test.tsx
+++ b/src/components/__tests__/ChatHistory.test.tsx
@@ -1,0 +1,505 @@
+/**
+ * Tests for ChatHistory component
+ */
+
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ChatHistory } from '../ChatHistory';
+
+// Mock fetch
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+const mockSessions = [
+  {
+    id: 3,
+    title: "Workout modification help",
+    createdAt: new Date().toISOString(),
+    preview: "How can I modify the Monday workout?",
+    messageCount: 8,
+  },
+  {
+    id: 2,
+    title: null,
+    createdAt: new Date(Date.now() - 86400000).toISOString(), // 1 day ago
+    preview: "What exercises help with back pain?",
+    messageCount: 4,
+  },
+  {
+    id: 1,
+    title: "Getting started",
+    createdAt: new Date(Date.now() - 7 * 86400000).toISOString(), // 7 days ago
+    preview: null,
+    messageCount: 0,
+  },
+];
+
+describe('ChatHistory', () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    onSelectSession: vi.fn(),
+    currentSessionId: null,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  describe('visibility', () => {
+    it('returns null when not open', () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ sessions: [], hasMore: false, nextCursor: null }),
+      });
+
+      const { container } = render(<ChatHistory {...defaultProps} isOpen={false} />);
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders when open', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ sessions: mockSessions, hasMore: false, nextCursor: null }),
+      });
+
+      render(<ChatHistory {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Chat History')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('loading state', () => {
+    it('shows loading indicator initially', () => {
+      mockFetch.mockImplementation(() => new Promise(() => {})); // Never resolves
+
+      render(<ChatHistory {...defaultProps} />);
+
+      // Loading state shows bouncing dots
+      expect(document.querySelectorAll('.animate-bounce')).toHaveLength(3);
+    });
+  });
+
+  describe('empty state', () => {
+    it('shows empty state when no sessions exist', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ sessions: [], hasMore: false, nextCursor: null }),
+      });
+
+      render(<ChatHistory {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('No conversations yet')).toBeInTheDocument();
+        expect(screen.getByText('Start chatting to see your history here.')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('error state', () => {
+    it('shows error message when fetch fails', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+      });
+
+      render(<ChatHistory {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Failed to load chat history')).toBeInTheDocument();
+      });
+    });
+
+    it('shows retry button on error', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+      });
+
+      render(<ChatHistory {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Try Again')).toBeInTheDocument();
+      });
+    });
+
+    it('retries fetch when retry button is clicked', async () => {
+      mockFetch
+        .mockResolvedValueOnce({ ok: false, status: 500 })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ sessions: mockSessions, hasMore: false, nextCursor: null }),
+        });
+
+      render(<ChatHistory {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Try Again')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('Try Again'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Workout modification help')).toBeInTheDocument();
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('session list', () => {
+    it('renders session list correctly', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ sessions: mockSessions, hasMore: false, nextCursor: null }),
+      });
+
+      render(<ChatHistory {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Workout modification help')).toBeInTheDocument();
+        expect(screen.getByText('Getting started')).toBeInTheDocument();
+      });
+    });
+
+    it('shows "New Chat" for sessions with null title', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ sessions: mockSessions, hasMore: false, nextCursor: null }),
+      });
+
+      render(<ChatHistory {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('New Chat')).toBeInTheDocument();
+      });
+    });
+
+    it('shows preview in quotes', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ sessions: mockSessions, hasMore: false, nextCursor: null }),
+      });
+
+      render(<ChatHistory {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/"How can I modify the Monday workout\?"/)).toBeInTheDocument();
+      });
+    });
+
+    it('shows message count', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ sessions: mockSessions, hasMore: false, nextCursor: null }),
+      });
+
+      render(<ChatHistory {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/8 messages/)).toBeInTheDocument();
+        expect(screen.getByText(/4 messages/)).toBeInTheDocument();
+        expect(screen.getByText(/0 messages/)).toBeInTheDocument();
+      });
+    });
+
+    it('shows singular "message" for count of 1', async () => {
+      const sessionsWithSingular = [
+        {
+          id: 1,
+          title: "Single message session",
+          createdAt: new Date().toISOString(),
+          preview: "Test",
+          messageCount: 1,
+        },
+      ];
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ sessions: sessionsWithSingular, hasMore: false, nextCursor: null }),
+      });
+
+      render(<ChatHistory {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/1 message$/)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('current session indicator', () => {
+    it('highlights currently active session', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ sessions: mockSessions, hasMore: false, nextCursor: null }),
+      });
+
+      render(<ChatHistory {...defaultProps} currentSessionId={3} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Current')).toBeInTheDocument();
+      });
+    });
+
+    it('does not show "Current" indicator for inactive sessions', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ sessions: mockSessions, hasMore: false, nextCursor: null }),
+      });
+
+      render(<ChatHistory {...defaultProps} currentSessionId={3} />);
+
+      await waitFor(() => {
+        const currentIndicators = screen.getAllByText('Current');
+        expect(currentIndicators).toHaveLength(1);
+      });
+    });
+  });
+
+  describe('session selection', () => {
+    it('calls onSelectSession when session is clicked', async () => {
+      const onSelectSession = vi.fn();
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ sessions: mockSessions, hasMore: false, nextCursor: null }),
+      });
+
+      render(<ChatHistory {...defaultProps} onSelectSession={onSelectSession} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Workout modification help')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('Workout modification help'));
+
+      expect(onSelectSession).toHaveBeenCalledWith(3);
+    });
+  });
+
+  describe('close functionality', () => {
+    it('calls onClose when close button is clicked', async () => {
+      const onClose = vi.fn();
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ sessions: mockSessions, hasMore: false, nextCursor: null }),
+      });
+
+      render(<ChatHistory {...defaultProps} onClose={onClose} />);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Close history')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByLabelText('Close history'));
+
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it('calls onClose when backdrop is clicked', async () => {
+      const onClose = vi.fn();
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ sessions: mockSessions, hasMore: false, nextCursor: null }),
+      });
+
+      render(<ChatHistory {...defaultProps} onClose={onClose} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Chat History')).toBeInTheDocument();
+      });
+
+      // Click the backdrop (first element with aria-hidden="true")
+      const backdrops = document.querySelectorAll('[aria-hidden="true"]');
+      fireEvent.click(backdrops[0]);
+
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('pagination', () => {
+    it('shows Load More button when hasMore is true', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          sessions: mockSessions,
+          hasMore: true,
+          nextCursor: 1,
+        }),
+      });
+
+      render(<ChatHistory {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Load More')).toBeInTheDocument();
+      });
+    });
+
+    it('does not show Load More button when hasMore is false', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          sessions: mockSessions,
+          hasMore: false,
+          nextCursor: null,
+        }),
+      });
+
+      render(<ChatHistory {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Workout modification help')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText('Load More')).not.toBeInTheDocument();
+    });
+
+    it('fetches more sessions when Load More is clicked', async () => {
+      const moreSessions = [
+        {
+          id: 0,
+          title: "Older session",
+          createdAt: new Date(Date.now() - 30 * 86400000).toISOString(),
+          preview: "Old message",
+          messageCount: 2,
+        },
+      ];
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({
+            sessions: mockSessions,
+            hasMore: true,
+            nextCursor: 1,
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({
+            sessions: moreSessions,
+            hasMore: false,
+            nextCursor: null,
+          }),
+        });
+
+      render(<ChatHistory {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Load More')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('Load More'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Older session')).toBeInTheDocument();
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenLastCalledWith('/api/chat/sessions?cursor=1');
+    });
+  });
+
+  describe('date formatting', () => {
+    it('shows "Today" for sessions from today', async () => {
+      const todaySession = [
+        {
+          id: 1,
+          title: "Today session",
+          createdAt: new Date().toISOString(),
+          preview: "Test",
+          messageCount: 1,
+        },
+      ];
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ sessions: todaySession, hasMore: false, nextCursor: null }),
+      });
+
+      render(<ChatHistory {...defaultProps} />);
+
+      await waitFor(() => {
+        // Look for the paragraph element containing date info
+        const dateElements = document.querySelectorAll('.text-slate-400');
+        const hasToday = Array.from(dateElements).some(el => el.textContent?.includes('Today'));
+        expect(hasToday).toBe(true);
+      });
+    });
+
+    it('shows "Yesterday" for sessions from yesterday', async () => {
+      const yesterdaySession = [
+        {
+          id: 1,
+          title: "Yesterday session",
+          createdAt: new Date(Date.now() - 86400000).toISOString(),
+          preview: "Test",
+          messageCount: 1,
+        },
+      ];
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ sessions: yesterdaySession, hasMore: false, nextCursor: null }),
+      });
+
+      render(<ChatHistory {...defaultProps} />);
+
+      await waitFor(() => {
+        // Look for the paragraph element containing date info
+        const dateElements = document.querySelectorAll('.text-slate-400');
+        const hasYesterday = Array.from(dateElements).some(el => el.textContent?.includes('Yesterday'));
+        expect(hasYesterday).toBe(true);
+      });
+    });
+
+    it('shows "X days ago" for recent sessions', async () => {
+      const recentSession = [
+        {
+          id: 1,
+          title: "Recent session",
+          createdAt: new Date(Date.now() - 3 * 86400000).toISOString(),
+          preview: "Test",
+          messageCount: 1,
+        },
+      ];
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ sessions: recentSession, hasMore: false, nextCursor: null }),
+      });
+
+      render(<ChatHistory {...defaultProps} />);
+
+      await waitFor(() => {
+        // Look for the paragraph element containing date info
+        const dateElements = document.querySelectorAll('.text-slate-400');
+        const hasDaysAgo = Array.from(dateElements).some(el => el.textContent?.includes('3 days ago'));
+        expect(hasDaysAgo).toBe(true);
+      });
+    });
+  });
+
+  describe('data fetching', () => {
+    it('fetches sessions when panel opens', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ sessions: [], hasMore: false, nextCursor: null }),
+      });
+
+      render(<ChatHistory {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith('/api/chat/sessions');
+      });
+    });
+
+    it('does not fetch when panel is closed', () => {
+      render(<ChatHistory {...defaultProps} isOpen={false} />);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `GET /api/chat/sessions` endpoint with pagination, preview extraction, and message count
- Create `ChatHistory` slide-in panel component with loading/error/empty states
- Add History button to `ChatModal` header next to New Chat button
- Implement session selection and loading functionality
- Show Current indicator for active session in history list
- Support relative date formatting (Today, Yesterday, X days ago)

Closes #126

## Test plan
- [x] All 603 unit tests passing
- [x] Lint passing (no errors)
- [x] Build passing
- [x] Manual testing with Playwright MCP verified:
  - [x] History button visible in chat modal header
  - [x] History panel opens when clicked
  - [x] Sessions display with title, date, preview, and message count
  - [x] Session loads correctly when selected
  - [x] Current session indicator shows on active session
  - [x] Empty state displays for users with no chat history

🤖 Generated with [Claude Code](https://claude.com/claude-code)