### PR TITLE
feat: add useFullscreen hook for cross-browser fullscreen API

### DIFF
--- a/src/lib/__tests__/fullscreen.test.ts
+++ b/src/lib/__tests__/fullscreen.test.ts
@@ -418,6 +418,41 @@ describe("useFullscreen", () => {
       expect(result.current.isFullscreen).toBe(false);
     });
 
+    it("reports isFullscreen false when a different element is fullscreen", () => {
+      // Create a different element that is NOT the ref
+      const differentElement = document.createElement("div");
+
+      const { result } = renderHook(() => useFullscreen(mockRef));
+
+      expect(result.current.isFullscreen).toBe(false);
+
+      // Simulate a different element entering fullscreen (not our ref)
+      Object.defineProperty(document, "fullscreenElement", {
+        value: differentElement,
+        configurable: true,
+      });
+
+      act(() => {
+        document.dispatchEvent(new Event("fullscreenchange"));
+      });
+
+      // isFullscreen should remain false because differentElement !== ref.current
+      expect(result.current.isFullscreen).toBe(false);
+
+      // Now simulate our element entering fullscreen
+      Object.defineProperty(document, "fullscreenElement", {
+        value: mockElement,
+        configurable: true,
+      });
+
+      act(() => {
+        document.dispatchEvent(new Event("fullscreenchange"));
+      });
+
+      // Now it should be true because mockElement === ref.current
+      expect(result.current.isFullscreen).toBe(true);
+    });
+
     it("handles webkit fullscreen element changes", () => {
       // Remove standard API
       Object.defineProperty(document, "fullscreenElement", {

--- a/src/lib/fullscreen.ts
+++ b/src/lib/fullscreen.ts
@@ -162,7 +162,8 @@ export function useFullscreen(
     if (typeof document === "undefined") return;
 
     const handleChange = () => {
-      setIsFullscreen(getFullscreenElement() !== null);
+      const fullscreenEl = getFullscreenElement();
+      setIsFullscreen(fullscreenEl !== null && fullscreenEl === ref.current);
     };
 
     // Listen to all vendor-prefixed fullscreen change events
@@ -180,7 +181,7 @@ export function useFullscreen(
         document.removeEventListener(event, handleChange)
       );
     };
-  }, [getFullscreenElement]);
+  }, [getFullscreenElement, ref]);
 
   return {
     isFullscreen,


### PR DESCRIPTION
## Summary
- Create `useFullscreen` hook in `src/lib/fullscreen.ts` with cross-browser fullscreen API support
- Add comprehensive unit tests in `src/lib/__tests__/fullscreen.test.ts` (24 tests)
- Support vendor prefixes: webkit (Safari), moz (Firefox), ms (IE11/Legacy Edge)

## API
```typescript
const { isFullscreen, toggleFullscreen, enterFullscreen, exitFullscreen, isSupported } = useFullscreen(ref);
```

## Features
- `isFullscreen` - Current fullscreen state
- `toggleFullscreen()` - Toggle fullscreen mode
- `enterFullscreen()` - Enter fullscreen mode
- `exitFullscreen()` - Exit fullscreen mode  
- `isSupported` - Whether Fullscreen API is available
- SSR-safe with proper document checks
- Automatic cleanup of event listeners
- Graceful error handling

## Test plan
- [x] All 24 unit tests pass
- [x] Full test suite (639 tests) passes
- [x] Lint passes
- [x] Production build succeeds
- [ ] Ready for integration into GuidedRoutinePlayer (issue #45)

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)