### PR TITLE
feat: standardize back button styling across workout pages

### DIFF
--- a/src/app/workouts/[slug]/page.tsx
+++ b/src/app/workouts/[slug]/page.tsx
@@ -91,7 +91,7 @@ export default async function WorkoutDetailPage({ params }: WorkoutPageProps) {
           <div className="flex items-center justify-between">
             <Link
               href="/"
-              className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400 hover:text-white transition"
+              className="rounded-full border border-white/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white transition hover:border-emerald-300 hover:text-emerald-200"
             >
               ← Back
             </Link>

--- a/src/app/workouts/nano/page.tsx
+++ b/src/app/workouts/nano/page.tsx
@@ -38,7 +38,7 @@ export default async function NanoWorkoutPage() {
           <header className="flex flex-col gap-6">
             <Link
               href="/"
-              className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400 transition hover:text-white"
+              className="rounded-full border border-white/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white transition hover:border-emerald-300 hover:text-emerald-200"
             >
               ← Back
             </Link>
@@ -73,7 +73,7 @@ export default async function NanoWorkoutPage() {
         <header className="flex flex-col gap-6">
           <Link
             href="/"
-            className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400 transition hover:text-white"
+            className="rounded-full border border-white/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white transition hover:border-emerald-300 hover:text-emerald-200"
           >
             ← Back
           </Link>


### PR DESCRIPTION
## Summary
- Updated back button on `/workouts/[slug]` detail page to use pill button style
- Updated back buttons on `/workouts/nano` page (both main view and limit reached view) to use pill button style
- All back buttons now match the player's existing style: `rounded-full border border-white/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white transition hover:border-emerald-300 hover:text-emerald-200`

Closes #128

## Test plan
- [x] Lint passes (0 errors, pre-existing warnings only)
- [x] Production build succeeds
- [x] All 640 unit tests pass
- [x] Visual verification via Playwright MCP on `/workouts/monday`, `/workouts/nano`, and `/workouts/nano/play`

🤖 Generated with [Claude Code](https://claude.com/claude-code)