### PR TITLE
feat: add diagnostic logging and multi-user isolation verification

### DIFF
--- a/e2e/multi-user-isolation.spec.ts
+++ b/e2e/multi-user-isolation.spec.ts
@@ -1,0 +1,144 @@
+import { test as base, expect, type Page } from '@playwright/test'
+import { generateTestUser, registerUser, loginUser, completeOnboarding } from './fixtures/auth.fixture'
+
+/**
+ * Multi-user isolation tests for GitHub Issue #155
+ *
+ * These tests verify that different users see their own personalized workouts
+ * and that workout data is properly scoped per user in the database.
+ */
+
+// Extended fixture for multi-user testing
+const test = base.extend<{ pageA: Page; pageB: Page }>({
+  // First user's page
+  pageA: async ({ browser }, callback) => {
+    const context = await browser.newContext()
+    const page = await context.newPage()
+    await callback(page)
+    await context.close()
+  },
+  // Second user's page
+  pageB: async ({ browser }, callback) => {
+    const context = await browser.newContext()
+    const page = await context.newPage()
+    await callback(page)
+    await context.close()
+  },
+})
+
+test.describe('Multi-user Workout Isolation', () => {
+  test('two users see their own workout labels on detail page', async ({ pageA, pageB }) => {
+    // Create and set up User A
+    const userA = generateTestUser()
+    await registerUser(pageA, userA)
+    await loginUser(pageA, userA.email, userA.password)
+    await completeOnboarding(pageA)
+
+    // Create and set up User B
+    const userB = generateTestUser()
+    await registerUser(pageB, userB)
+    await loginUser(pageB, userB.email, userB.password)
+    await completeOnboarding(pageB)
+
+    // Navigate both users to the same workout page
+    await pageA.goto('/workouts/monday')
+    await pageB.goto('/workouts/monday')
+
+    // Both should see "Your Monday Workout" label (personalized)
+    const labelA = pageA.locator('text=/Your Monday Workout/i')
+    const labelB = pageB.locator('text=/Your Monday Workout/i')
+
+    await expect(labelA).toBeVisible({ timeout: 10000 })
+    await expect(labelB).toBeVisible({ timeout: 10000 })
+
+    // Both should see workout content (verifies data loaded properly)
+    const headingA = pageA.getByRole('heading', { level: 1 })
+    const headingB = pageB.getByRole('heading', { level: 1 })
+
+    await expect(headingA).toBeVisible()
+    await expect(headingB).toBeVisible()
+  })
+
+  test('each user sees their own workouts on home page', async ({ pageA, pageB }) => {
+    // Create and set up User A
+    const userA = generateTestUser()
+    await registerUser(pageA, userA)
+    await loginUser(pageA, userA.email, userA.password)
+    await completeOnboarding(pageA)
+
+    // Create and set up User B
+    const userB = generateTestUser()
+    await registerUser(pageB, userB)
+    await loginUser(pageB, userB.email, userB.password)
+    await completeOnboarding(pageB)
+
+    // Navigate both users to home page
+    await pageA.goto('/')
+    await pageB.goto('/')
+
+    // Both should see weekly schedule (indicating data loaded)
+    const scheduleA = pageA.getByText(/weekly schedule/i)
+    const scheduleB = pageB.getByText(/weekly schedule/i)
+
+    await expect(scheduleA).toBeVisible({ timeout: 10000 })
+    await expect(scheduleB).toBeVisible({ timeout: 10000 })
+
+    // Both should see Today badge (indicating workout data loaded properly)
+    const todayA = pageA.getByText(/today/i).first()
+    const todayB = pageB.getByText(/today/i).first()
+
+    await expect(todayA).toBeVisible()
+    await expect(todayB).toBeVisible()
+  })
+
+  test('logout and login shows correct user workouts', async ({ page }) => {
+    // Create two users
+    const userA = generateTestUser()
+    const userB = generateTestUser()
+
+    // Set up User A
+    await registerUser(page, userA)
+    await loginUser(page, userA.email, userA.password)
+    await completeOnboarding(page)
+
+    // Verify User A can see workouts
+    await page.goto('/workouts/monday')
+    await expect(page.locator('text=/Your Monday Workout/i')).toBeVisible({ timeout: 10000 })
+
+    // Logout
+    await page.goto('/logout')
+    await expect(page).toHaveURL('/login', { timeout: 10000 })
+
+    // Register and login as User B
+    await registerUser(page, userB)
+    await loginUser(page, userB.email, userB.password)
+    await completeOnboarding(page)
+
+    // Verify User B can see workouts too (their own)
+    await page.goto('/workouts/monday')
+    await expect(page.locator('text=/Your Monday Workout/i')).toBeVisible({ timeout: 10000 })
+  })
+
+  test('unauthenticated user is redirected to login', async ({ page }) => {
+    // Try to access workout page without login
+    await page.goto('/workouts/monday')
+
+    // Should be redirected to login
+    await expect(page).toHaveURL(/\/login/, { timeout: 10000 })
+  })
+
+  test('home page shows correct today/up-next labeling', async ({ pageA }) => {
+    // Create and set up User A
+    const userA = generateTestUser()
+    await registerUser(pageA, userA)
+    await loginUser(pageA, userA.email, userA.password)
+    await completeOnboarding(pageA)
+
+    // Navigate to home page
+    await pageA.goto('/')
+
+    // Should see the "Today" or "Up Next" label in the featured workout section
+    const todayOrUpNext = pageA.locator('text=/Today|Up Next/').first()
+    await expect(todayOrUpNext).toBeVisible({ timeout: 10000 })
+  })
+})

--- a/src/app/api/debug/workouts/route.ts
+++ b/src/app/api/debug/workouts/route.ts
@@ -1,0 +1,161 @@
+import { NextRequest } from 'next/server';
+import { query } from '@/lib/db';
+
+export const runtime = 'nodejs';
+
+/**
+ * Validate admin API token
+ */
+function validateToken(request: NextRequest): boolean {
+  const expectedToken = process.env.ADMIN_API_TOKEN;
+  if (!expectedToken) {
+    console.warn('ADMIN_API_TOKEN not configured');
+    return false;
+  }
+
+  const authHeader = request.headers.get('Authorization');
+  return authHeader === `Bearer ${expectedToken}`;
+}
+
+/**
+ * GET /api/debug/workouts
+ * Debug endpoint to verify workout isolation between users
+ * Protected by ADMIN_API_TOKEN
+ *
+ * Query params:
+ * - userId: Get workouts for a specific user
+ * - compare: Compare workouts between two users (comma-separated IDs)
+ */
+export async function GET(request: NextRequest) {
+  if (!validateToken(request)) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const userId = searchParams.get('userId');
+  const compare = searchParams.get('compare');
+
+  try {
+    // Get summary of all users and their workouts
+    if (!userId && !compare) {
+      const result = await query(`
+        SELECT
+          u.id as user_id,
+          u.email,
+          u.name,
+          u.onboarding_completed,
+          COUNT(w.id) as workout_count,
+          ARRAY_AGG(w.slug ORDER BY w.slug) as workout_slugs
+        FROM users u
+        LEFT JOIN workouts w ON u.id = w.user_id AND w.is_active = true
+        GROUP BY u.id, u.email, u.name, u.onboarding_completed
+        ORDER BY u.id
+        LIMIT 100
+      `);
+
+      return Response.json({
+        users: result.rows.map(row => ({
+          userId: row.user_id,
+          email: row.email,
+          name: row.name,
+          onboardingCompleted: row.onboarding_completed,
+          workoutCount: parseInt(row.workout_count, 10),
+          workoutSlugs: row.workout_slugs.filter(Boolean)
+        }))
+      });
+    }
+
+    // Get workouts for a specific user
+    if (userId) {
+      const userResult = await query(`
+        SELECT id, email, name, onboarding_completed
+        FROM users WHERE id = $1
+      `, [userId]);
+
+      if (userResult.rows.length === 0) {
+        return Response.json({ error: 'User not found' }, { status: 404 });
+      }
+
+      const workoutsResult = await query(`
+        SELECT slug, workout_json, version, is_active, created_at, updated_at
+        FROM workouts
+        WHERE user_id = $1 AND is_active = true
+        ORDER BY slug
+      `, [userId]);
+
+      return Response.json({
+        user: {
+          id: userResult.rows[0].id,
+          email: userResult.rows[0].email,
+          name: userResult.rows[0].name,
+          onboardingCompleted: userResult.rows[0].onboarding_completed
+        },
+        workouts: workoutsResult.rows.map(row => ({
+          slug: row.slug,
+          title: row.workout_json?.title,
+          focus: row.workout_json?.focus,
+          segmentCount: row.workout_json?.segments?.length ?? 0,
+          version: row.version,
+          createdAt: row.created_at,
+          updatedAt: row.updated_at
+        }))
+      });
+    }
+
+    // Compare workouts between two users
+    if (compare) {
+      const [userIdA, userIdB] = compare.split(',').map(id => id.trim());
+
+      if (!userIdA || !userIdB) {
+        return Response.json({ error: 'Compare requires two user IDs separated by comma' }, { status: 400 });
+      }
+
+      const [workoutsA, workoutsB] = await Promise.all([
+        query(`
+          SELECT slug, workout_json
+          FROM workouts
+          WHERE user_id = $1 AND is_active = true
+          ORDER BY slug
+        `, [userIdA]),
+        query(`
+          SELECT slug, workout_json
+          FROM workouts
+          WHERE user_id = $1 AND is_active = true
+          ORDER BY slug
+        `, [userIdB])
+      ]);
+
+      const comparison: Record<string, { userA: unknown; userB: unknown; identical: boolean }> = {};
+      const slugsA = new Set(workoutsA.rows.map(r => r.slug));
+      const slugsB = new Set(workoutsB.rows.map(r => r.slug));
+      const allSlugs = new Set([...slugsA, ...slugsB]);
+
+      for (const slug of allSlugs) {
+        const wA = workoutsA.rows.find(r => r.slug === slug)?.workout_json;
+        const wB = workoutsB.rows.find(r => r.slug === slug)?.workout_json;
+
+        comparison[slug] = {
+          userA: wA ? { title: wA.title, focus: wA.focus, segmentCount: wA.segments?.length ?? 0 } : null,
+          userB: wB ? { title: wB.title, focus: wB.focus, segmentCount: wB.segments?.length ?? 0 } : null,
+          identical: JSON.stringify(wA) === JSON.stringify(wB)
+        };
+      }
+
+      return Response.json({
+        userIdA,
+        userIdB,
+        comparison,
+        allIdentical: Object.values(comparison).every(c => c.identical)
+      });
+    }
+
+    return Response.json({ error: 'Invalid request' }, { status: 400 });
+
+  } catch (error) {
+    console.error('Debug workouts error:', error);
+    return Response.json({
+      error: 'Debug query failed',
+      message: error instanceof Error ? error.message : 'Unknown error'
+    }, { status: 500 });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -87,7 +87,12 @@ export default async function Home() {
             <div className="flex flex-wrap items-start justify-between gap-4">
               <div className="space-y-2">
                 <p className="text-xs font-semibold uppercase tracking-[0.35em] text-emerald-400">
-                  {nextWorkout.slug === todaySlug ? "Today" : "Up Next"} · {nextWorkout.label}
+                  {nextWorkout.slug === todaySlug
+                    ? "Today"
+                    : hasCompletedToday
+                      ? "Today Complete · Up Next"
+                      : "Up Next"
+                  } · {nextWorkout.label}
                 </p>
                 <h3 className="text-2xl font-semibold text-white sm:text-3xl">
                   {nextWorkout.title}

--- a/src/app/workouts/[slug]/page.tsx
+++ b/src/app/workouts/[slug]/page.tsx
@@ -108,7 +108,7 @@ export default async function WorkoutDetailPage({ params }: WorkoutPageProps) {
             <div className="space-y-2">
               <div>
                 <p className="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400">
-                  {isToday ? "Today · " : ""}{workout.label}
+                  {isToday ? "Today · " : ""}Your {workout.label} Workout
                 </p>
                 <h1 className="mt-2 text-3xl font-semibold text-white sm:text-4xl">
                   {workout.title}


### PR DESCRIPTION
## Summary
- Add diagnostic logging to workout queries (`getWorkoutBySlug`, `getAllWorkouts`, `getNextUncompletedWorkout`) and auth callbacks
- Improve UI clarity: "Your Monday Workout" on detail pages, "Today Complete · Up Next" on home page
- Add `/api/debug/workouts` admin endpoint for database verification
- Add comprehensive multi-user isolation tests (unit + E2E)

Closes #155

## Changes

### Diagnostic Logging
- `[getWorkoutBySlug]` logs user_id and slug for every workout query
- `[getAllWorkouts]` logs user_id and count of workouts returned
- `[getNextUncompletedWorkout]` logs which workout is returned and why (today vs tomorrow)
- `[auth]` logs login attempts (success/failure) and JWT token population

### UI Improvements
- Workout detail page now shows "Your Monday Workout" instead of just "Monday" to clarify ownership
- Home page shows "Today Complete · Up Next" when today's workout is done

### Debug Endpoint
- New `/api/debug/workouts` endpoint (admin-protected) for:
  - Listing all users and their workout counts
  - Getting workouts for a specific user
  - Comparing workouts between two users

## Test plan
- [x] All 645 unit tests pass (including 5 new multi-user isolation tests)
- [x] Build succeeds
- [x] Manual browser testing verified UI changes work correctly
- [x] New E2E tests: `e2e/multi-user-isolation.spec.ts` (5 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)