### PR TITLE
feat: localize recipe detail page UI text based on user locale

### DIFF
--- a/src/app/recipes/[slug]/page.tsx
+++ b/src/app/recipes/[slug]/page.tsx
@@ -2,7 +2,9 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import { auth } from "@/lib/auth";
 import { getRecipeBySlug } from "@/lib/recipes";
+import { getRecipeDetailTranslations } from "@/lib/translations/recipe-detail";
 import { RecipeImageGallery } from "@/components/RecipeImageGallery";
 import { PageContextSetter } from "@/components/PageContextSetter";
 
@@ -42,6 +44,11 @@ export default async function RecipeDetailPage({
     notFound();
   }
 
+  // Get user's locale for UI translations
+  const session = await auth();
+  const userLocale = session?.user?.locale ?? 'en-US';
+  const t = getRecipeDetailTranslations(userLocale);
+
   const { recipeJson } = recipe;
 
   return (
@@ -55,7 +62,7 @@ export default async function RecipeDetailPage({
               href="/recipes"
               className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400 transition hover:text-white"
             >
-              ← Back to recipes
+              {t.backToRecipes}
             </Link>
           </div>
 
@@ -78,14 +85,14 @@ export default async function RecipeDetailPage({
                 href={`/recipes/${slug}/edit`}
                 className="inline-flex items-center justify-center rounded-full bg-slate-800 px-4 py-2 text-sm font-medium text-white hover:bg-slate-700 transition"
               >
-                Edit
+                {t.edit}
               </Link>
               <button
                 disabled
                 className="inline-flex cursor-not-allowed items-center justify-center rounded-full bg-slate-800 px-4 py-2 text-sm font-medium text-slate-500"
                 title="Coming soon"
               >
-                Share
+                {t.share}
               </button>
             </div>
           </div>
@@ -106,7 +113,7 @@ export default async function RecipeDetailPage({
               <div className="flex items-center gap-2">
                 <span className="text-xl">🕐</span>
                 <div>
-                  <p className="text-xs text-slate-400">Prep</p>
+                  <p className="text-xs text-slate-400">{t.prepTime}</p>
                   <p className="font-medium text-white">
                     {recipeJson.prepTimeMinutes} min
                   </p>
@@ -117,7 +124,7 @@ export default async function RecipeDetailPage({
               <div className="flex items-center gap-2">
                 <span className="text-xl">🍳</span>
                 <div>
-                  <p className="text-xs text-slate-400">Cook</p>
+                  <p className="text-xs text-slate-400">{t.cookTime}</p>
                   <p className="font-medium text-white">
                     {recipeJson.cookTimeMinutes} min
                   </p>
@@ -127,7 +134,7 @@ export default async function RecipeDetailPage({
             <div className="flex items-center gap-2">
               <span className="text-xl">👥</span>
               <div>
-                <p className="text-xs text-slate-400">Servings</p>
+                <p className="text-xs text-slate-400">{t.servings}</p>
                 <p className="font-medium text-white">{recipeJson.servings}</p>
               </div>
             </div>
@@ -140,28 +147,28 @@ export default async function RecipeDetailPage({
           aria-label="Nutrition information"
         >
           <div className="border-b border-slate-800 px-5 py-4 sm:px-6">
-            <h2 className="text-lg font-semibold text-white">Nutrition</h2>
-            <p className="mt-1 text-sm text-slate-400">Per serving</p>
+            <h2 className="text-lg font-semibold text-white">{t.nutrition}</h2>
+            <p className="mt-1 text-sm text-slate-400">{t.perServing}</p>
           </div>
           <div className="overflow-x-auto">
             <table className="w-full">
               <thead>
                 <tr className="border-b border-slate-800 text-xs text-slate-400">
                   <th className="px-5 py-3 text-left font-medium sm:px-6">
-                    Energie
+                    {t.energy}
                   </th>
                   <th className="px-5 py-3 text-left font-medium sm:px-6">
-                    Protein
+                    {t.protein}
                   </th>
                   <th className="px-5 py-3 text-left font-medium sm:px-6">
-                    Kohlenhydrate
+                    {t.carbohydrates}
                   </th>
                   <th className="px-5 py-3 text-left font-medium sm:px-6">
-                    Fett
+                    {t.fat}
                   </th>
                   {recipeJson.nutrition.fiber !== undefined && (
                     <th className="px-5 py-3 text-left font-medium sm:px-6">
-                      Ballaststoffe
+                      {t.fiber}
                     </th>
                   )}
                 </tr>
@@ -213,7 +220,7 @@ export default async function RecipeDetailPage({
           aria-label="Ingredients"
         >
           <div className="border-b border-slate-800 px-5 py-4 sm:px-6">
-            <h2 className="text-lg font-semibold text-white">Zutaten</h2>
+            <h2 className="text-lg font-semibold text-white">{t.ingredients}</h2>
           </div>
           <div className="divide-y divide-slate-800">
             {recipeJson.ingredientGroups.map((group, groupIndex) => (
@@ -247,7 +254,7 @@ export default async function RecipeDetailPage({
           aria-label="Instructions"
         >
           <div className="border-b border-slate-800 px-5 py-4 sm:px-6">
-            <h2 className="text-lg font-semibold text-white">Zubereitung</h2>
+            <h2 className="text-lg font-semibold text-white">{t.instructions}</h2>
           </div>
           <ol className="divide-y divide-slate-800">
             {recipeJson.steps.map((step) => (

--- a/src/lib/translations/__tests__/recipe-detail.test.ts
+++ b/src/lib/translations/__tests__/recipe-detail.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  getRecipeDetailTranslations,
+  type RecipeDetailTranslations,
+} from '../recipe-detail';
+
+// All required translation keys
+const requiredKeys: (keyof RecipeDetailTranslations)[] = [
+  'backToRecipes',
+  'edit',
+  'share',
+  'prepTime',
+  'cookTime',
+  'servings',
+  'nutrition',
+  'perServing',
+  'energy',
+  'protein',
+  'carbohydrates',
+  'fat',
+  'fiber',
+  'ingredients',
+  'instructions',
+];
+
+describe('getRecipeDetailTranslations', () => {
+  describe('English (en-US)', () => {
+    it('returns English translations for en-US locale', () => {
+      const t = getRecipeDetailTranslations('en-US');
+
+      expect(t.backToRecipes).toBe('← Back to recipes');
+      expect(t.edit).toBe('Edit');
+      expect(t.share).toBe('Share');
+      expect(t.nutrition).toBe('Nutrition');
+      expect(t.ingredients).toBe('Ingredients');
+      expect(t.instructions).toBe('Instructions');
+    });
+
+    it('returns English translations for en-GB locale (variant)', () => {
+      const t = getRecipeDetailTranslations('en-GB');
+
+      // en-GB should map to en-US translations
+      expect(t.backToRecipes).toBe('← Back to recipes');
+      expect(t.edit).toBe('Edit');
+      expect(t.nutrition).toBe('Nutrition');
+    });
+  });
+
+  describe('German (de-DE)', () => {
+    it('returns German translations for de-DE locale', () => {
+      const t = getRecipeDetailTranslations('de-DE');
+
+      expect(t.backToRecipes).toBe('← Zurück zu Rezepten');
+      expect(t.edit).toBe('Bearbeiten');
+      expect(t.share).toBe('Teilen');
+      expect(t.nutrition).toBe('Nährwerte');
+      expect(t.ingredients).toBe('Zutaten');
+      expect(t.instructions).toBe('Zubereitung');
+    });
+
+    it('returns German translations for de-AT locale (variant)', () => {
+      const t = getRecipeDetailTranslations('de-AT');
+
+      // de-AT should map to de-DE translations
+      expect(t.backToRecipes).toBe('← Zurück zu Rezepten');
+      expect(t.nutrition).toBe('Nährwerte');
+    });
+
+    it('returns German translations for de-CH locale (variant)', () => {
+      const t = getRecipeDetailTranslations('de-CH');
+
+      // de-CH should map to de-DE translations
+      expect(t.backToRecipes).toBe('← Zurück zu Rezepten');
+      expect(t.nutrition).toBe('Nährwerte');
+    });
+  });
+
+  describe('French (fr-FR)', () => {
+    it('returns French translations for fr-FR locale', () => {
+      const t = getRecipeDetailTranslations('fr-FR');
+
+      expect(t.backToRecipes).toBe('← Retour aux recettes');
+      expect(t.edit).toBe('Modifier');
+      expect(t.nutrition).toBe('Nutrition');
+      expect(t.ingredients).toBe('Ingrédients');
+    });
+  });
+
+  describe('Spanish (es-ES)', () => {
+    it('returns Spanish translations for es-ES locale', () => {
+      const t = getRecipeDetailTranslations('es-ES');
+
+      expect(t.backToRecipes).toBe('← Volver a recetas');
+      expect(t.edit).toBe('Editar');
+      expect(t.ingredients).toBe('Ingredientes');
+    });
+  });
+
+  describe('Japanese (ja-JP)', () => {
+    it('returns Japanese translations for ja-JP locale', () => {
+      const t = getRecipeDetailTranslations('ja-JP');
+
+      expect(t.backToRecipes).toBe('← レシピ一覧に戻る');
+      expect(t.edit).toBe('編集');
+      expect(t.ingredients).toBe('材料');
+    });
+  });
+
+  describe('Chinese Simplified (zh-CN)', () => {
+    it('returns Chinese translations for zh-CN locale', () => {
+      const t = getRecipeDetailTranslations('zh-CN');
+
+      expect(t.backToRecipes).toBe('← 返回食谱列表');
+      expect(t.edit).toBe('编辑');
+      expect(t.ingredients).toBe('食材');
+    });
+  });
+
+  describe('fallback behavior', () => {
+    it('falls back to English for unsupported locale', () => {
+      const t = getRecipeDetailTranslations('ko-KR');
+
+      // Should return English translations
+      expect(t.backToRecipes).toBe('← Back to recipes');
+      expect(t.edit).toBe('Edit');
+      expect(t.nutrition).toBe('Nutrition');
+    });
+
+    it('falls back to English for empty string', () => {
+      const t = getRecipeDetailTranslations('');
+
+      expect(t.backToRecipes).toBe('← Back to recipes');
+    });
+
+    it('falls back to English for invalid locale format', () => {
+      const t = getRecipeDetailTranslations('invalid');
+
+      expect(t.backToRecipes).toBe('← Back to recipes');
+    });
+  });
+
+  describe('translation completeness', () => {
+    const supportedLocales = [
+      'en-US',
+      'de-DE',
+      'fr-FR',
+      'es-ES',
+      'it-IT',
+      'nl-NL',
+      'pt-BR',
+      'ja-JP',
+      'zh-CN',
+    ];
+
+    it.each(supportedLocales)(
+      '%s has all required translation keys',
+      (locale) => {
+        const t = getRecipeDetailTranslations(locale);
+
+        for (const key of requiredKeys) {
+          expect(t[key]).toBeDefined();
+          expect(typeof t[key]).toBe('string');
+          expect(t[key].length).toBeGreaterThan(0);
+        }
+      }
+    );
+
+    it.each(supportedLocales)(
+      '%s has unique translations (not copy of English, except en-US)',
+      (locale) => {
+        if (locale === 'en-US') {
+          return; // Skip English check
+        }
+
+        const t = getRecipeDetailTranslations(locale);
+        const en = getRecipeDetailTranslations('en-US');
+
+        // At least some keys should differ from English
+        const differentKeys = requiredKeys.filter((key) => t[key] !== en[key]);
+        expect(differentKeys.length).toBeGreaterThan(0);
+      }
+    );
+  });
+
+  describe('locale variant mapping', () => {
+    it('maps en-GB to en-US translations', () => {
+      const enGB = getRecipeDetailTranslations('en-GB');
+      const enUS = getRecipeDetailTranslations('en-US');
+
+      for (const key of requiredKeys) {
+        expect(enGB[key]).toBe(enUS[key]);
+      }
+    });
+
+    it('maps de-AT to de-DE translations', () => {
+      const deAT = getRecipeDetailTranslations('de-AT');
+      const deDE = getRecipeDetailTranslations('de-DE');
+
+      for (const key of requiredKeys) {
+        expect(deAT[key]).toBe(deDE[key]);
+      }
+    });
+
+    it('maps de-CH to de-DE translations', () => {
+      const deCH = getRecipeDetailTranslations('de-CH');
+      const deDE = getRecipeDetailTranslations('de-DE');
+
+      for (const key of requiredKeys) {
+        expect(deCH[key]).toBe(deDE[key]);
+      }
+    });
+  });
+});

--- a/src/lib/translations/recipe-detail.ts
+++ b/src/lib/translations/recipe-detail.ts
@@ -1,0 +1,197 @@
+/**
+ * Translations for the recipe detail page UI text.
+ * The actual recipe content (title, ingredients, steps) remains in its stored locale.
+ */
+
+export type RecipeDetailTranslations = {
+  backToRecipes: string;
+  edit: string;
+  share: string;
+  prepTime: string;
+  cookTime: string;
+  servings: string;
+  nutrition: string;
+  perServing: string;
+  energy: string;
+  protein: string;
+  carbohydrates: string;
+  fat: string;
+  fiber: string;
+  ingredients: string;
+  instructions: string;
+};
+
+const translations: Record<string, RecipeDetailTranslations> = {
+  'en-US': {
+    backToRecipes: '← Back to recipes',
+    edit: 'Edit',
+    share: 'Share',
+    prepTime: 'Prep',
+    cookTime: 'Cook',
+    servings: 'Servings',
+    nutrition: 'Nutrition',
+    perServing: 'Per serving',
+    energy: 'Energy',
+    protein: 'Protein',
+    carbohydrates: 'Carbohydrates',
+    fat: 'Fat',
+    fiber: 'Fiber',
+    ingredients: 'Ingredients',
+    instructions: 'Instructions',
+  },
+  'de-DE': {
+    backToRecipes: '← Zurück zu Rezepten',
+    edit: 'Bearbeiten',
+    share: 'Teilen',
+    prepTime: 'Vorbereitung',
+    cookTime: 'Kochen',
+    servings: 'Portionen',
+    nutrition: 'Nährwerte',
+    perServing: 'Pro Portion',
+    energy: 'Energie',
+    protein: 'Protein',
+    carbohydrates: 'Kohlenhydrate',
+    fat: 'Fett',
+    fiber: 'Ballaststoffe',
+    ingredients: 'Zutaten',
+    instructions: 'Zubereitung',
+  },
+  'fr-FR': {
+    backToRecipes: '← Retour aux recettes',
+    edit: 'Modifier',
+    share: 'Partager',
+    prepTime: 'Préparation',
+    cookTime: 'Cuisson',
+    servings: 'Portions',
+    nutrition: 'Nutrition',
+    perServing: 'Par portion',
+    energy: 'Énergie',
+    protein: 'Protéines',
+    carbohydrates: 'Glucides',
+    fat: 'Lipides',
+    fiber: 'Fibres',
+    ingredients: 'Ingrédients',
+    instructions: 'Instructions',
+  },
+  'es-ES': {
+    backToRecipes: '← Volver a recetas',
+    edit: 'Editar',
+    share: 'Compartir',
+    prepTime: 'Preparación',
+    cookTime: 'Cocción',
+    servings: 'Porciones',
+    nutrition: 'Nutrición',
+    perServing: 'Por porción',
+    energy: 'Energía',
+    protein: 'Proteína',
+    carbohydrates: 'Carbohidratos',
+    fat: 'Grasa',
+    fiber: 'Fibra',
+    ingredients: 'Ingredientes',
+    instructions: 'Instrucciones',
+  },
+  'it-IT': {
+    backToRecipes: '← Torna alle ricette',
+    edit: 'Modifica',
+    share: 'Condividi',
+    prepTime: 'Preparazione',
+    cookTime: 'Cottura',
+    servings: 'Porzioni',
+    nutrition: 'Valori nutrizionali',
+    perServing: 'Per porzione',
+    energy: 'Energia',
+    protein: 'Proteine',
+    carbohydrates: 'Carboidrati',
+    fat: 'Grassi',
+    fiber: 'Fibre',
+    ingredients: 'Ingredienti',
+    instructions: 'Istruzioni',
+  },
+  'nl-NL': {
+    backToRecipes: '← Terug naar recepten',
+    edit: 'Bewerken',
+    share: 'Delen',
+    prepTime: 'Voorbereiding',
+    cookTime: 'Koken',
+    servings: 'Porties',
+    nutrition: 'Voedingswaarde',
+    perServing: 'Per portie',
+    energy: 'Energie',
+    protein: 'Eiwitten',
+    carbohydrates: 'Koolhydraten',
+    fat: 'Vet',
+    fiber: 'Vezels',
+    ingredients: 'Ingrediënten',
+    instructions: 'Bereiding',
+  },
+  'pt-BR': {
+    backToRecipes: '← Voltar para receitas',
+    edit: 'Editar',
+    share: 'Compartilhar',
+    prepTime: 'Preparo',
+    cookTime: 'Cozimento',
+    servings: 'Porções',
+    nutrition: 'Nutrição',
+    perServing: 'Por porção',
+    energy: 'Energia',
+    protein: 'Proteína',
+    carbohydrates: 'Carboidratos',
+    fat: 'Gordura',
+    fiber: 'Fibras',
+    ingredients: 'Ingredientes',
+    instructions: 'Modo de preparo',
+  },
+  'ja-JP': {
+    backToRecipes: '← レシピ一覧に戻る',
+    edit: '編集',
+    share: '共有',
+    prepTime: '下準備',
+    cookTime: '調理時間',
+    servings: '人分',
+    nutrition: '栄養成分',
+    perServing: '1人分あたり',
+    energy: 'カロリー',
+    protein: 'たんぱく質',
+    carbohydrates: '炭水化物',
+    fat: '脂質',
+    fiber: '食物繊維',
+    ingredients: '材料',
+    instructions: '作り方',
+  },
+  'zh-CN': {
+    backToRecipes: '← 返回食谱列表',
+    edit: '编辑',
+    share: '分享',
+    prepTime: '准备时间',
+    cookTime: '烹饪时间',
+    servings: '份量',
+    nutrition: '营养成分',
+    perServing: '每份',
+    energy: '能量',
+    protein: '蛋白质',
+    carbohydrates: '碳水化合物',
+    fat: '脂肪',
+    fiber: '膳食纤维',
+    ingredients: '食材',
+    instructions: '做法',
+  },
+};
+
+// Mapping for locale variants to their base locale
+const localeVariantMap: Record<string, string> = {
+  'en-GB': 'en-US',
+  'de-AT': 'de-DE',
+  'de-CH': 'de-DE',
+};
+
+/**
+ * Get translations for the recipe detail page based on user locale.
+ * Falls back to English (en-US) for unsupported locales.
+ */
+export function getRecipeDetailTranslations(locale: string): RecipeDetailTranslations {
+  // Check for locale variant mapping
+  const baseLocale = localeVariantMap[locale] ?? locale;
+
+  // Return translations for the locale, falling back to English
+  return translations[baseLocale] ?? translations['en-US'];
+}


### PR DESCRIPTION
## Summary
- Add translation utility (`src/lib/translations/recipe-detail.ts`) with support for 9 locales
- Update recipe detail page to use translations based on user's locale preference
- Support locale variants (en-GB → en-US, de-AT/de-CH → de-DE)
- Fall back to English (en-US) for unsupported locales

## Supported Locales
| Locale | Language |
|--------|----------|
| en-US, en-GB | English |
| de-DE, de-AT, de-CH | German |
| fr-FR | French |
| es-ES | Spanish |
| it-IT | Italian |
| nl-NL | Dutch |
| pt-BR | Portuguese (Brazil) |
| ja-JP | Japanese |
| zh-CN | Chinese (Simplified) |

## Translated UI Elements
- Navigation: "Back to recipes" link
- Action buttons: Edit, Share
- Time & Servings: Prep, Cook, Servings labels
- Nutrition: Section title, "Per serving", nutrient names (Energy, Protein, Carbohydrates, Fat, Fiber)
- Content sections: Ingredients and Instructions headings

## Test plan
- [x] Unit tests pass (33 new test cases for translation utility)
- [x] Build succeeds
- [x] Manual testing with German locale shows German translations
- [x] Manual testing with English locale shows English translations
- [x] Locale change in settings immediately affects recipe detail page

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)