### PR TITLE
fix: return full recipe object from POST /api/recipes endpoint

### DIFF
--- a/src/app/api/recipes/__tests__/route.test.ts
+++ b/src/app/api/recipes/__tests__/route.test.ts
@@ -143,12 +143,12 @@ describe("POST /api/recipes", () => {
     expect(data.error).toBe("Missing required fields: title and recipeJson");
   });
 
-  it("creates recipe and returns slug and version", async () => {
+  it("creates recipe and returns recipe object", async () => {
     mockAuth.mockResolvedValue({
       user: { id: "1", email: "test@example.com" },
       expires: new Date().toISOString(),
     });
-    mockCreateRecipe.mockResolvedValue({
+    const mockRecipe = {
       id: 1,
       userId: 1,
       slug: "new-recipe",
@@ -161,14 +161,17 @@ describe("POST /api/recipes", () => {
       isActive: true,
       createdAt: new Date(),
       updatedAt: new Date(),
-    });
+    };
+    mockCreateRecipe.mockResolvedValue(mockRecipe);
 
     const request = createRequest("POST", validRecipeInput);
     const response = await POST(request);
     const data = await response.json();
 
     expect(response.status).toBe(201);
-    expect(data).toEqual({ slug: "new-recipe", version: 1 });
+    expect(data.recipe).toBeDefined();
+    expect(data.recipe.slug).toBe("new-recipe");
+    expect(data.recipe.version).toBe(1);
   });
 
   it("returns 500 on error", async () => {

--- a/src/app/api/recipes/route.ts
+++ b/src/app/api/recipes/route.ts
@@ -55,7 +55,7 @@ export async function POST(request: Request) {
     }
 
     const recipe = await createRecipe(body);
-    return Response.json({ slug: recipe.slug, version: recipe.version }, { status: 201 });
+    return Response.json({ recipe }, { status: 201 });
   } catch (error) {
     console.error("Error creating recipe:", error);
     return Response.json(


### PR DESCRIPTION
## Summary
- Changed POST `/api/recipes` endpoint response from `{ slug, version }` to `{ recipe }` to match the format expected by the client (`RecipeForm.tsx`)
- This maintains consistency with the PATCH endpoint which already returns `{ recipe }`

## Root Cause
The client at `RecipeForm.tsx:200` expected `data.recipe.slug` but the POST endpoint returned `{ slug, version }` causing "Cannot read properties of undefined (reading 'slug')" error when creating new recipes.

## Test plan
- [x] npm run lint passes
- [x] npm run build passes
- [x] All 717 unit tests pass
- [x] Manual testing: Created new recipe via form, verified redirect works correctly

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)