### PR TITLE
feat: apply unit system preference to recipe ingredient display

### DIFF
--- a/src/app/recipes/[slug]/page.tsx
+++ b/src/app/recipes/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { getRecipeBySlug } from "@/lib/recipes";
 import { getRecipeDetailTranslations } from "@/lib/translations/recipe-detail";
+import { convertIngredientUnit } from "@/lib/unit-utils";
 import { RecipeImageGallery } from "@/components/RecipeImageGallery";
 import { PageContextSetter } from "@/components/PageContextSetter";
 
@@ -44,9 +45,10 @@ export default async function RecipeDetailPage({
     notFound();
   }
 
-  // Get user's locale for UI translations
+  // Get user's locale and unit system preferences
   const session = await auth();
   const userLocale = session?.user?.locale ?? 'en-US';
+  const userUnitSystem = session?.user?.unitSystem ?? 'metric';
   const t = getRecipeDetailTranslations(userLocale);
 
   const { recipeJson } = recipe;
@@ -231,17 +233,24 @@ export default async function RecipeDetailPage({
                   </p>
                 </div>
                 <ul className="px-5 pb-5 sm:px-6">
-                  {group.ingredients.map((ingredient, index) => (
-                    <li
-                      key={`${ingredient.name}-${index}`}
-                      className="flex items-baseline gap-2 py-2"
-                    >
-                      <span className="font-medium text-white">
-                        {ingredient.quantity} {ingredient.unit}
-                      </span>
-                      <span className="text-slate-300">{ingredient.name}</span>
-                    </li>
-                  ))}
+                  {group.ingredients.map((ingredient, index) => {
+                    const converted = convertIngredientUnit(
+                      ingredient.quantity,
+                      ingredient.unit,
+                      userUnitSystem
+                    );
+                    return (
+                      <li
+                        key={`${ingredient.name}-${index}`}
+                        className="flex items-baseline gap-2 py-2"
+                      >
+                        <span className="font-medium text-white">
+                          {converted.quantity} {converted.unit}
+                        </span>
+                        <span className="text-slate-300">{ingredient.name}</span>
+                      </li>
+                    );
+                  })}
                 </ul>
               </div>
             ))}

--- a/src/lib/__tests__/unit-utils.test.ts
+++ b/src/lib/__tests__/unit-utils.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect } from 'vitest';
+import {
+  kgToLbs,
+  lbsToKg,
+  gToOz,
+  mlToFlOz,
+  formatWeight,
+  convertIngredientUnit,
+} from '../unit-utils';
+
+describe('unit-utils', () => {
+  describe('kgToLbs', () => {
+    it('converts kilograms to pounds', () => {
+      expect(kgToLbs(1)).toBeCloseTo(2.205, 2);
+      expect(kgToLbs(16)).toBeCloseTo(35.27, 1);
+    });
+
+    it('handles zero', () => {
+      expect(kgToLbs(0)).toBe(0);
+    });
+
+    it('handles fractional values', () => {
+      expect(kgToLbs(0.5)).toBeCloseTo(1.1, 1);
+    });
+  });
+
+  describe('lbsToKg', () => {
+    it('converts pounds to kilograms', () => {
+      expect(lbsToKg(2.205)).toBeCloseTo(1, 1);
+      expect(lbsToKg(45)).toBeCloseTo(20.4, 1);
+    });
+
+    it('handles zero', () => {
+      expect(lbsToKg(0)).toBe(0);
+    });
+  });
+
+  describe('gToOz', () => {
+    it('converts grams to ounces', () => {
+      expect(gToOz(100)).toBeCloseTo(3.53, 1);
+      expect(gToOz(28.35)).toBeCloseTo(1, 1);
+    });
+
+    it('handles zero', () => {
+      expect(gToOz(0)).toBe(0);
+    });
+  });
+
+  describe('mlToFlOz', () => {
+    it('converts milliliters to fluid ounces', () => {
+      expect(mlToFlOz(100)).toBeCloseTo(3.38, 1);
+      expect(mlToFlOz(29.57)).toBeCloseTo(1, 1);
+    });
+
+    it('handles zero', () => {
+      expect(mlToFlOz(0)).toBe(0);
+    });
+  });
+
+  describe('formatWeight', () => {
+    it('formats weight in metric system', () => {
+      expect(formatWeight(16, 'kg', 'metric')).toBe('16 kg');
+      expect(formatWeight(200, 'g', 'metric')).toBe('200 g');
+    });
+
+    it('converts and formats weight in imperial system', () => {
+      expect(formatWeight(16, 'kg', 'imperial')).toBe('35 lbs');
+      expect(formatWeight(100, 'g', 'imperial')).toBe('4 oz');
+    });
+
+    it('handles zero values', () => {
+      expect(formatWeight(0, 'kg', 'metric')).toBe('0 kg');
+      expect(formatWeight(0, 'kg', 'imperial')).toBe('0 lbs');
+    });
+  });
+
+  describe('convertIngredientUnit', () => {
+    describe('unit-agnostic ingredients', () => {
+      it('returns unchanged for piece-like units', () => {
+        expect(convertIngredientUnit(2, 'cloves', 'imperial')).toEqual({
+          quantity: 2,
+          unit: 'cloves',
+        });
+        expect(convertIngredientUnit(1, 'pinch', 'metric')).toEqual({
+          quantity: 1,
+          unit: 'pinch',
+        });
+        expect(convertIngredientUnit(3, 'pieces', 'imperial')).toEqual({
+          quantity: 3,
+          unit: 'pieces',
+        });
+      });
+
+      it('handles empty unit', () => {
+        expect(convertIngredientUnit(1, '', 'metric')).toEqual({
+          quantity: 1,
+          unit: '',
+        });
+      });
+    });
+
+    describe('metric to imperial conversion', () => {
+      it('converts grams to ounces', () => {
+        const result = convertIngredientUnit(100, 'g', 'imperial');
+        expect(result.quantity).toBe(3.5);
+        expect(result.unit).toBe('oz');
+      });
+
+      it('converts milliliters to fluid ounces', () => {
+        const result = convertIngredientUnit(250, 'ml', 'imperial');
+        expect(result.quantity).toBe(8.5);
+        expect(result.unit).toBe('fl oz');
+      });
+
+      it('converts kilograms to pounds', () => {
+        const result = convertIngredientUnit(1, 'kg', 'imperial');
+        expect(result.quantity).toBe(2.2);
+        expect(result.unit).toBe('lbs');
+      });
+
+      it('converts liters to cups', () => {
+        const result = convertIngredientUnit(1, 'l', 'imperial');
+        expect(result.quantity).toBe(4.2);
+        expect(result.unit).toBe('cups');
+      });
+    });
+
+    describe('imperial to metric conversion', () => {
+      it('converts ounces to grams', () => {
+        const result = convertIngredientUnit(4, 'oz', 'metric');
+        expect(result.quantity).toBe(113);
+        expect(result.unit).toBe('g');
+      });
+
+      it('converts fluid ounces to milliliters', () => {
+        const result = convertIngredientUnit(8, 'fl oz', 'metric');
+        expect(result.quantity).toBe(237);
+        expect(result.unit).toBe('ml');
+      });
+
+      it('converts pounds to kilograms', () => {
+        const result = convertIngredientUnit(2.2, 'lbs', 'metric');
+        expect(result.quantity).toBe(1);
+        expect(result.unit).toBe('kg');
+      });
+
+      it('converts lb to kilograms (singular form)', () => {
+        const result = convertIngredientUnit(2.2, 'lb', 'metric');
+        expect(result.quantity).toBe(1);
+        expect(result.unit).toBe('kg');
+      });
+
+      it('converts cups to milliliters', () => {
+        const result = convertIngredientUnit(1, 'cups', 'metric');
+        expect(result.quantity).toBe(237);
+        expect(result.unit).toBe('ml');
+      });
+
+      it('converts tablespoons to milliliters', () => {
+        const result = convertIngredientUnit(2, 'tbsp', 'metric');
+        expect(result.quantity).toBe(30);
+        expect(result.unit).toBe('ml');
+      });
+
+      it('converts teaspoons to milliliters', () => {
+        const result = convertIngredientUnit(1, 'tsp', 'metric');
+        expect(result.quantity).toBe(5);
+        expect(result.unit).toBe('ml');
+      });
+    });
+
+    describe('same system - no conversion', () => {
+      it('returns metric unchanged when target is metric', () => {
+        expect(convertIngredientUnit(100, 'g', 'metric')).toEqual({
+          quantity: 100,
+          unit: 'g',
+        });
+        expect(convertIngredientUnit(250, 'ml', 'metric')).toEqual({
+          quantity: 250,
+          unit: 'ml',
+        });
+      });
+
+      it('returns imperial unchanged when target is imperial', () => {
+        expect(convertIngredientUnit(4, 'oz', 'imperial')).toEqual({
+          quantity: 4,
+          unit: 'oz',
+        });
+        expect(convertIngredientUnit(2, 'cups', 'imperial')).toEqual({
+          quantity: 2,
+          unit: 'cups',
+        });
+      });
+    });
+
+    describe('case insensitivity', () => {
+      it('handles uppercase units', () => {
+        expect(convertIngredientUnit(100, 'G', 'imperial')).toEqual({
+          quantity: 3.5,
+          unit: 'oz',
+        });
+        expect(convertIngredientUnit(4, 'OZ', 'metric')).toEqual({
+          quantity: 113,
+          unit: 'g',
+        });
+      });
+
+      it('handles mixed case units', () => {
+        expect(convertIngredientUnit(250, 'ML', 'imperial')).toEqual({
+          quantity: 8.5,
+          unit: 'fl oz',
+        });
+      });
+    });
+
+    describe('edge cases', () => {
+      it('handles zero quantity', () => {
+        expect(convertIngredientUnit(0, 'g', 'imperial')).toEqual({
+          quantity: 0,
+          unit: 'oz',
+        });
+      });
+
+      it('handles whitespace in unit', () => {
+        expect(convertIngredientUnit(100, ' g ', 'imperial')).toEqual({
+          quantity: 3.5,
+          unit: 'oz',
+        });
+      });
+    });
+  });
+});

--- a/src/lib/unit-utils.ts
+++ b/src/lib/unit-utils.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit conversion utilities for metric/imperial unit systems
+ */
+
+import type { UnitSystem } from './user-preferences';
+
+// Conversion constants
+const KG_TO_LBS = 2.20462;
+const G_TO_OZ = 0.035274;
+const ML_TO_FLOZ = 0.033814;
+const L_TO_CUPS = 4.22675;
+const ML_PER_CUP = 236.588;
+
+// Weight conversions
+export function kgToLbs(kg: number): number {
+  return kg * KG_TO_LBS;
+}
+
+export function lbsToKg(lbs: number): number {
+  return lbs / KG_TO_LBS;
+}
+
+// Volume conversions
+export function mlToFlOz(ml: number): number {
+  return ml * ML_TO_FLOZ;
+}
+
+export function gToOz(g: number): number {
+  return g * G_TO_OZ;
+}
+
+// Format weight with appropriate unit
+export function formatWeight(
+  value: number,
+  fromUnit: 'kg' | 'g',
+  targetSystem: UnitSystem
+): string {
+  if (targetSystem === 'metric') {
+    return fromUnit === 'kg' ? `${value} kg` : `${value} g`;
+  }
+  // Convert to imperial
+  if (fromUnit === 'kg') {
+    return `${Math.round(kgToLbs(value))} lbs`;
+  }
+  return `${Math.round(gToOz(value))} oz`;
+}
+
+// Known metric units
+const METRIC_UNITS = ['g', 'ml', 'kg', 'l'];
+
+// Known imperial units
+const IMPERIAL_UNITS = ['oz', 'cups', 'tbsp', 'tsp', 'lb', 'lbs', 'fl oz'];
+
+/**
+ * Convert ingredient quantity and unit to user's preferred unit system
+ * Returns the quantity and unit unchanged if:
+ * - Unit is unit-agnostic (e.g., "pieces", "cloves")
+ * - Unit is already in the target system
+ */
+export function convertIngredientUnit(
+  quantity: number,
+  unit: string,
+  targetSystem: UnitSystem
+): { quantity: number; unit: string } {
+  const normalizedUnit = unit.toLowerCase().trim();
+
+  const isMetric = METRIC_UNITS.includes(normalizedUnit);
+  const isImperial = IMPERIAL_UNITS.includes(normalizedUnit);
+
+  // If unit doesn't match either system (e.g., "pieces", "cloves"), return as-is
+  if (!isMetric && !isImperial) {
+    return { quantity, unit };
+  }
+
+  // If already in target system, return as-is
+  if (
+    (targetSystem === 'metric' && isMetric) ||
+    (targetSystem === 'imperial' && isImperial)
+  ) {
+    return { quantity, unit };
+  }
+
+  // Convert metric to imperial
+  if (targetSystem === 'imperial' && isMetric) {
+    switch (normalizedUnit) {
+      case 'g':
+        return {
+          quantity: Math.round(quantity * G_TO_OZ * 10) / 10,
+          unit: 'oz',
+        };
+      case 'ml':
+        return {
+          quantity: Math.round(quantity * ML_TO_FLOZ * 10) / 10,
+          unit: 'fl oz',
+        };
+      case 'kg':
+        return {
+          quantity: Math.round(quantity * KG_TO_LBS * 10) / 10,
+          unit: 'lbs',
+        };
+      case 'l':
+        return {
+          quantity: Math.round(quantity * L_TO_CUPS * 10) / 10,
+          unit: 'cups',
+        };
+      default:
+        return { quantity, unit };
+    }
+  }
+
+  // Convert imperial to metric
+  if (targetSystem === 'metric' && isImperial) {
+    switch (normalizedUnit) {
+      case 'oz':
+        return { quantity: Math.round(quantity / G_TO_OZ), unit: 'g' };
+      case 'fl oz':
+        return { quantity: Math.round(quantity / ML_TO_FLOZ), unit: 'ml' };
+      case 'lb':
+      case 'lbs':
+        return {
+          quantity: Math.round((quantity / KG_TO_LBS) * 10) / 10,
+          unit: 'kg',
+        };
+      case 'cups':
+        return { quantity: Math.round(quantity * ML_PER_CUP), unit: 'ml' };
+      case 'tbsp':
+        // 1 tbsp ≈ 15 ml
+        return { quantity: Math.round(quantity * 15), unit: 'ml' };
+      case 'tsp':
+        // 1 tsp ≈ 5 ml
+        return { quantity: Math.round(quantity * 5), unit: 'ml' };
+      default:
+        return { quantity, unit };
+    }
+  }
+
+  return { quantity, unit };
+}


### PR DESCRIPTION
## Summary
- Add unit conversion utilities for metric/imperial conversions (g ↔ oz, ml ↔ fl oz, kg ↔ lbs, l ↔ cups)
- Update recipe detail page to convert ingredient quantities based on user's unit system preference
- Unit-agnostic ingredients (pieces, cloves, etc.) remain unchanged

Closes #123

## Test plan
- [x] Unit tests pass (31 new tests for conversion utilities)
- [x] Manual testing: recipe ingredients display correctly in both metric and imperial
- [x] Unit-agnostic ingredients (e.g., "1 Stück Banane") remain unchanged
- [x] Lint and build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)