### PR TITLE
fix: handle singular 'cup' unit in imperial to metric conversion

### DIFF
--- a/src/lib/__tests__/unit-utils.test.ts
+++ b/src/lib/__tests__/unit-utils.test.ts
@@ -156,6 +156,12 @@ describe('unit-utils', () => {
         expect(result.unit).toBe('ml');
       });
 
+      it('converts cup to milliliters (singular form)', () => {
+        const result = convertIngredientUnit(1, 'cup', 'metric');
+        expect(result.quantity).toBe(237);
+        expect(result.unit).toBe('ml');
+      });
+
       it('converts tablespoons to milliliters', () => {
         const result = convertIngredientUnit(2, 'tbsp', 'metric');
         expect(result.quantity).toBe(30);
@@ -189,6 +195,13 @@ describe('unit-utils', () => {
         expect(convertIngredientUnit(2, 'cups', 'imperial')).toEqual({
           quantity: 2,
           unit: 'cups',
+        });
+      });
+
+      it('returns cup unchanged when target is imperial (singular form)', () => {
+        expect(convertIngredientUnit(1, 'cup', 'imperial')).toEqual({
+          quantity: 1,
+          unit: 'cup',
         });
       });
     });

--- a/src/lib/unit-utils.ts
+++ b/src/lib/unit-utils.ts
@@ -49,7 +49,7 @@ export function formatWeight(
 const METRIC_UNITS = ['g', 'ml', 'kg', 'l'];
 
 // Known imperial units
-const IMPERIAL_UNITS = ['oz', 'cups', 'tbsp', 'tsp', 'lb', 'lbs', 'fl oz'];
+const IMPERIAL_UNITS = ['oz', 'cup', 'cups', 'tbsp', 'tsp', 'lb', 'lbs', 'fl oz'];
 
 /**
  * Convert ingredient quantity and unit to user's preferred unit system
@@ -121,6 +121,7 @@ export function convertIngredientUnit(
           quantity: Math.round((quantity / KG_TO_LBS) * 10) / 10,
           unit: 'kg',
         };
+      case 'cup':
       case 'cups':
         return { quantity: Math.round(quantity * ML_PER_CUP), unit: 'ml' };
       case 'tbsp':


### PR DESCRIPTION
## Summary
- Add `cup` (singular) to `IMPERIAL_UNITS` array alongside existing `cups`
- Add `cup` case to the switch statement for imperial-to-metric conversion
- Add unit tests for singular `cup` handling

## Problem
The `convertIngredientUnit` function was not recognizing `cup` (singular) as an imperial unit, only `cups` (plural). This caused ingredients like "1 cup flour" to not be converted when the user prefers metric units.

## Test plan
- [x] Unit test: `converts cup to milliliters (singular form)` - verifies 1 cup → 237 ml
- [x] Unit test: `returns cup unchanged when target is imperial (singular form)` - verifies no conversion when already imperial
- [x] All 750 existing unit tests pass
- [x] ESLint passes
- [x] Production build succeeds

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)