### PR TITLE
feat: show persistent tool call indicators in chat messages

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1076,8 +1076,11 @@ ${memoryContext}${pageContextSection}${instructionSection}`;
             }
           }
 
-          // Send done signal
-          controller.enqueue(encoder.encode(`data: ${JSON.stringify({ type: "done" })}\n\n`));
+          // Send done signal with tool calls for persistent display
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify({
+            type: "done",
+            toolCalls: allToolCalls.length > 0 ? allToolCalls : undefined
+          })}\n\n`));
 
           // Save assistant message to DB
           await query(`


### PR DESCRIPTION
## Summary
- Add visual indicators above assistant messages showing which tools were used
- Indicators display with a checkmark icon and past-tense label (e.g., "✓ Fetched workout", "✓ Saved to memory")
- Tool indicators persist for historical messages loaded from session history

## Changes
- Extended `Message` interface with `toolCalls` field in `ChatModal.tsx`
- Added `TOOL_DISPLAY_NAMES` constant with past-tense display names
- Updated API `done` event to include `toolCalls` array in `route.ts`
- Load `toolCalls` from session history when switching sessions
- Render persistent tool indicator chips above assistant messages

## Test plan
- [x] Send a message that triggers tool use (e.g., "What's my workout today?")
- [x] Verify tool indicator appears after response completes (e.g., "✓ Fetched workout")
- [x] Verify indicator persists after scrolling
- [x] Build and lint pass
- [x] All unit tests pass (750 tests)

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)