### PR TITLE
feat: implement predefined tag system for recipe categorization

### DIFF
--- a/src/app/api/recipes/tags/route.ts
+++ b/src/app/api/recipes/tags/route.ts
@@ -1,0 +1,54 @@
+/**
+ * API endpoint for recipe tags
+ * Returns predefined tags and user's custom tags
+ */
+
+import { auth } from "@/lib/auth";
+import { getUserTags } from "@/lib/recipes";
+import {
+  PREDEFINED_TAGS,
+  TAG_CATEGORIES,
+  type PredefinedTag,
+  type TagCategoryInfo,
+  type TagCategory,
+} from "@/lib/predefined-tags";
+
+export const runtime = "nodejs";
+
+export interface TagsResponse {
+  /** All predefined tags with metadata */
+  predefined: PredefinedTag[];
+  /** User's custom tags (not in predefined list) */
+  custom: string[];
+  /** Category metadata for UI grouping */
+  categories: Record<TagCategory, TagCategoryInfo>;
+}
+
+/**
+ * GET /api/recipes/tags
+ * Get all available tags (predefined + user's custom)
+ */
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    // Get user's existing tags from database
+    const userTags = await getUserTags();
+
+    // Filter out predefined tags to get custom ones
+    const predefinedIds = new Set(PREDEFINED_TAGS.map((t) => t.id));
+    const customTags = userTags.filter((tag) => !predefinedIds.has(tag));
+
+    return Response.json({
+      predefined: PREDEFINED_TAGS,
+      custom: customTags,
+      categories: TAG_CATEGORIES,
+    } satisfies TagsResponse);
+  } catch (error) {
+    console.error("Error fetching tags:", error);
+    return Response.json({ error: "Failed to fetch tags" }, { status: 500 });
+  }
+}

--- a/src/app/recipes/[slug]/edit/page.tsx
+++ b/src/app/recipes/[slug]/edit/page.tsx
@@ -4,6 +4,7 @@ import { redirect, notFound } from 'next/navigation';
 import { auth } from '@/lib/auth';
 import { getRecipeBySlug, getUserTags } from '@/lib/recipes';
 import { RecipeForm } from '@/components/RecipeForm';
+import { PREDEFINED_TAGS, TAG_CATEGORIES } from '@/lib/predefined-tags';
 
 export const dynamic = 'force-dynamic';
 
@@ -53,6 +54,8 @@ export default async function EditRecipePage({ params }: PageProps) {
           initialRecipe={recipe.recipeJson}
           slug={slug}
           existingTags={existingTags}
+          predefinedTags={PREDEFINED_TAGS}
+          tagCategories={TAG_CATEGORIES}
         />
       </div>
     </main>

--- a/src/app/recipes/new/page.tsx
+++ b/src/app/recipes/new/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from 'next/navigation';
 import { auth } from '@/lib/auth';
 import { getUserTags } from '@/lib/recipes';
 import { RecipeForm } from '@/components/RecipeForm';
+import { PREDEFINED_TAGS, TAG_CATEGORIES } from '@/lib/predefined-tags';
 
 export const dynamic = 'force-dynamic';
 
@@ -41,7 +42,12 @@ export default async function NewRecipePage() {
         </h1>
 
         {/* Form */}
-        <RecipeForm existingTags={existingTags} defaultLocale={userLocale} />
+        <RecipeForm
+          existingTags={existingTags}
+          predefinedTags={PREDEFINED_TAGS}
+          tagCategories={TAG_CATEGORIES}
+          defaultLocale={userLocale}
+        />
       </div>
     </main>
   );

--- a/src/app/recipes/page.tsx
+++ b/src/app/recipes/page.tsx
@@ -6,6 +6,7 @@ import { auth } from "@/lib/auth";
 import { getUserRecipeSummaries, getUserTags } from "@/lib/recipes";
 import { LogoutButton } from "@/components/LogoutButton";
 import { RecipeListClient } from "@/components/RecipeListClient";
+import { PREDEFINED_TAGS } from "@/lib/predefined-tags";
 
 export const dynamic = "force-dynamic";
 
@@ -67,6 +68,7 @@ export default async function RecipesPage() {
           <RecipeListClient
             initialRecipes={recipes}
             availableTags={availableTags}
+            predefinedTags={PREDEFINED_TAGS}
           />
         </Suspense>
       </div>

--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 
 import { RecipeSummary } from "@/lib/recipe-types";
 import { StarRating } from "./StarRating";
+import { getTagById, getTagColorClass } from "@/lib/predefined-tags";
 
 interface RecipeCardProps {
   recipe: RecipeSummary;
@@ -83,14 +84,21 @@ export function RecipeCard({ recipe, href }: RecipeCardProps) {
         {/* Tags */}
         {visibleTags.length > 0 && (
           <div className="flex flex-wrap gap-1.5">
-            {visibleTags.map((tag) => (
-              <span
-                key={tag}
-                className="inline-flex items-center rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs text-emerald-400"
-              >
-                {tag}
-              </span>
-            ))}
+            {visibleTags.map((tag) => {
+              // Get predefined tag info for display label and color
+              const predefinedTag = getTagById(tag);
+              const colorClass = getTagColorClass(tag);
+              const displayLabel = predefinedTag?.label || tag;
+
+              return (
+                <span
+                  key={tag}
+                  className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs ${colorClass}`}
+                >
+                  {displayLabel}
+                </span>
+              );
+            })}
             {extraTagCount > 0 && (
               <span className="inline-flex items-center rounded-full bg-slate-500/10 px-2 py-0.5 text-xs text-slate-400">
                 +{extraTagCount} more

--- a/src/components/RecipeForm.tsx
+++ b/src/components/RecipeForm.tsx
@@ -14,6 +14,7 @@ import type {
   NutritionInfo,
 } from '@/lib/recipe-types';
 import { generateSlug } from '@/lib/recipe-types';
+import type { PredefinedTag, TagCategory, TagCategoryInfo } from '@/lib/predefined-tags';
 
 interface RecipeFormProps {
   /** Initial recipe data for editing, undefined for new recipe */
@@ -22,6 +23,10 @@ interface RecipeFormProps {
   slug?: string;
   /** Available tags for autocomplete */
   existingTags?: string[];
+  /** Predefined tags with category metadata */
+  predefinedTags?: PredefinedTag[];
+  /** Category metadata for UI grouping */
+  tagCategories?: Partial<Record<TagCategory, TagCategoryInfo>>;
   /** Default locale for new recipes (from user preferences) */
   defaultLocale?: string;
 }
@@ -59,7 +64,14 @@ const DEFAULT_FORM_STATE: FormState = {
   images: [],
 };
 
-export function RecipeForm({ initialRecipe, slug, existingTags = [], defaultLocale = 'en-US' }: RecipeFormProps) {
+export function RecipeForm({
+  initialRecipe,
+  slug,
+  existingTags = [],
+  predefinedTags = [],
+  tagCategories = {},
+  defaultLocale = 'en-US',
+}: RecipeFormProps) {
   const router = useRouter();
   const isEditing = Boolean(slug);
 
@@ -262,6 +274,8 @@ export function RecipeForm({ initialRecipe, slug, existingTags = [], defaultLoca
             tags={form.tags}
             onChange={(tags) => updateField('tags', tags)}
             suggestions={existingTags}
+            predefinedTags={predefinedTags}
+            categories={tagCategories}
             disabled={loading}
           />
         </div>

--- a/src/components/RecipeListClient.tsx
+++ b/src/components/RecipeListClient.tsx
@@ -11,10 +11,12 @@ import {
   countActiveFilters,
 } from "@/lib/recipe-filter-utils";
 import { RecipeCard } from "./RecipeCard";
+import type { PredefinedTag, TagCategory } from "@/lib/predefined-tags";
 
 interface RecipeListClientProps {
   initialRecipes: RecipeSummary[];
   availableTags: string[];
+  predefinedTags?: PredefinedTag[];
 }
 
 // ============================================
@@ -89,9 +91,34 @@ const PlusIcon = () => (
 // Component
 // ============================================
 
+// Category color mapping for tag chips
+const CATEGORY_CHIP_COLORS: Record<TagCategory, { selected: string; unselected: string }> = {
+  meal: {
+    selected: "bg-blue-500 text-slate-950",
+    unselected: "bg-blue-500/20 text-blue-400 hover:bg-blue-500/30",
+  },
+  diet: {
+    selected: "bg-green-500 text-slate-950",
+    unselected: "bg-green-500/20 text-green-400 hover:bg-green-500/30",
+  },
+  cuisine: {
+    selected: "bg-orange-500 text-slate-950",
+    unselected: "bg-orange-500/20 text-orange-400 hover:bg-orange-500/30",
+  },
+  category: {
+    selected: "bg-purple-500 text-slate-950",
+    unselected: "bg-purple-500/20 text-purple-400 hover:bg-purple-500/30",
+  },
+  effort: {
+    selected: "bg-yellow-500 text-slate-950",
+    unselected: "bg-yellow-500/20 text-yellow-400 hover:bg-yellow-500/30",
+  },
+};
+
 export function RecipeListClient({
   initialRecipes,
   availableTags,
+  predefinedTags = [],
 }: RecipeListClientProps) {
   const router = useRouter();
   const pathname = usePathname();
@@ -218,17 +245,32 @@ export function RecipeListClient({
           <div className="flex gap-2 pb-1">
             {availableTags.map((tag) => {
               const isSelected = selectedTags.includes(tag);
+              // Find predefined tag for category color
+              const predefinedTag = predefinedTags.find(pt => pt.id === tag);
+              const category = predefinedTag?.category;
+
+              // Get color classes based on category
+              let colorClass: string;
+              if (isSelected) {
+                colorClass = category
+                  ? `${CATEGORY_CHIP_COLORS[category].selected} font-medium`
+                  : "bg-emerald-500 font-medium text-slate-950";
+              } else {
+                colorClass = category
+                  ? CATEGORY_CHIP_COLORS[category].unselected
+                  : "bg-slate-800 text-slate-300 hover:bg-slate-700";
+              }
+
+              // Display label: use German label for predefined, tag ID for custom
+              const displayLabel = predefinedTag?.label || tag;
+
               return (
                 <button
                   key={tag}
                   onClick={() => toggleTag(tag)}
-                  className={`shrink-0 rounded-full px-3 py-1.5 text-sm transition ${
-                    isSelected
-                      ? "bg-emerald-500 font-medium text-slate-950"
-                      : "bg-slate-800 text-slate-300 hover:bg-slate-700"
-                  }`}
+                  className={`shrink-0 rounded-full px-3 py-1.5 text-sm transition ${colorClass}`}
                 >
-                  {tag}
+                  {displayLabel}
                 </button>
               );
             })}

--- a/src/components/__tests__/RecipeCard.test.tsx
+++ b/src/components/__tests__/RecipeCard.test.tsx
@@ -55,9 +55,11 @@ describe("RecipeCard", () => {
 
   it("renders recipe tags (limited to 3)", () => {
     render(<RecipeCard recipe={mockRecipe} />);
+    // "healthy" is custom tag, displayed as-is
     expect(screen.getByText("healthy")).toBeInTheDocument();
-    expect(screen.getByText("quick")).toBeInTheDocument();
-    expect(screen.getByText("vegetarian")).toBeInTheDocument();
+    // "quick" and "vegetarian" are predefined tags, displayed with German labels
+    expect(screen.getByText("Schnell")).toBeInTheDocument();
+    expect(screen.getByText("Vegetarisch")).toBeInTheDocument();
   });
 
   it("renders +N more indicator when more than 3 tags", () => {

--- a/src/lib/__tests__/predefined-tags.test.ts
+++ b/src/lib/__tests__/predefined-tags.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PREDEFINED_TAGS,
+  TAG_CATEGORIES,
+  TAG_CATEGORY_ORDER,
+  CATEGORY_COLORS,
+  getPredefinedTagIds,
+  getTagById,
+  getTagsByCategory,
+  isPredefinedTag,
+  getTagCategory,
+  getTagColorClass,
+  getGroupedPredefinedTags,
+  type TagCategory,
+} from '../predefined-tags';
+
+describe('predefined-tags', () => {
+  describe('PREDEFINED_TAGS', () => {
+    it('has all expected categories represented', () => {
+      const categories = new Set(PREDEFINED_TAGS.map(t => t.category));
+      expect(categories).toContain('meal');
+      expect(categories).toContain('diet');
+      expect(categories).toContain('cuisine');
+      expect(categories).toContain('category');
+      expect(categories).toContain('effort');
+    });
+
+    it('has unique tag IDs', () => {
+      const ids = PREDEFINED_TAGS.map(t => t.id);
+      const uniqueIds = new Set(ids);
+      expect(uniqueIds.size).toBe(ids.length);
+    });
+
+    it('all tags have required properties', () => {
+      for (const tag of PREDEFINED_TAGS) {
+        expect(tag.id).toBeDefined();
+        expect(tag.id.length).toBeGreaterThan(0);
+        expect(tag.label).toBeDefined();
+        expect(tag.label.length).toBeGreaterThan(0);
+        expect(tag.labelEn).toBeDefined();
+        expect(tag.labelEn.length).toBeGreaterThan(0);
+        expect(tag.category).toBeDefined();
+      }
+    });
+
+    it('tag IDs are lowercase and hyphenated', () => {
+      for (const tag of PREDEFINED_TAGS) {
+        expect(tag.id).toBe(tag.id.toLowerCase());
+        expect(tag.id).not.toContain(' ');
+        // Allow alphanumeric and hyphens only
+        expect(tag.id).toMatch(/^[a-z0-9-]+$/);
+      }
+    });
+  });
+
+  describe('TAG_CATEGORIES', () => {
+    it('has all expected categories', () => {
+      expect(TAG_CATEGORIES).toHaveProperty('meal');
+      expect(TAG_CATEGORIES).toHaveProperty('diet');
+      expect(TAG_CATEGORIES).toHaveProperty('cuisine');
+      expect(TAG_CATEGORIES).toHaveProperty('category');
+      expect(TAG_CATEGORIES).toHaveProperty('effort');
+    });
+
+    it('each category has label and labelEn', () => {
+      for (const category of Object.values(TAG_CATEGORIES)) {
+        expect(category.label).toBeDefined();
+        expect(category.labelEn).toBeDefined();
+      }
+    });
+  });
+
+  describe('TAG_CATEGORY_ORDER', () => {
+    it('contains all categories', () => {
+      const categoryKeys = Object.keys(TAG_CATEGORIES) as TagCategory[];
+      expect(TAG_CATEGORY_ORDER).toHaveLength(categoryKeys.length);
+      for (const category of categoryKeys) {
+        expect(TAG_CATEGORY_ORDER).toContain(category);
+      }
+    });
+  });
+
+  describe('CATEGORY_COLORS', () => {
+    it('has colors for all categories', () => {
+      for (const category of TAG_CATEGORY_ORDER) {
+        expect(CATEGORY_COLORS[category]).toBeDefined();
+        expect(CATEGORY_COLORS[category]).toMatch(/^bg-.*text-.*/);
+      }
+    });
+  });
+
+  describe('getPredefinedTagIds', () => {
+    it('returns all tag IDs', () => {
+      const ids = getPredefinedTagIds();
+      expect(ids).toHaveLength(PREDEFINED_TAGS.length);
+      for (const tag of PREDEFINED_TAGS) {
+        expect(ids).toContain(tag.id);
+      }
+    });
+  });
+
+  describe('getTagById', () => {
+    it('returns tag for valid predefined ID', () => {
+      const tag = getTagById('breakfast');
+      expect(tag).toBeDefined();
+      expect(tag?.id).toBe('breakfast');
+      expect(tag?.category).toBe('meal');
+    });
+
+    it('returns undefined for non-existent ID', () => {
+      const tag = getTagById('non-existent-tag');
+      expect(tag).toBeUndefined();
+    });
+
+    it('returns undefined for custom tag ID', () => {
+      const tag = getTagById('my-custom-tag');
+      expect(tag).toBeUndefined();
+    });
+  });
+
+  describe('getTagsByCategory', () => {
+    it('returns only tags of specified category', () => {
+      const mealTags = getTagsByCategory('meal');
+      expect(mealTags.length).toBeGreaterThan(0);
+      for (const tag of mealTags) {
+        expect(tag.category).toBe('meal');
+      }
+    });
+
+    it('returns all expected meal tags', () => {
+      const mealTags = getTagsByCategory('meal');
+      const mealIds = mealTags.map(t => t.id);
+      expect(mealIds).toContain('breakfast');
+      expect(mealIds).toContain('lunch');
+      expect(mealIds).toContain('dinner');
+    });
+
+    it('returns all expected diet tags', () => {
+      const dietTags = getTagsByCategory('diet');
+      const dietIds = dietTags.map(t => t.id);
+      expect(dietIds).toContain('vegetarian');
+      expect(dietIds).toContain('vegan');
+      expect(dietIds).toContain('high-protein');
+    });
+  });
+
+  describe('isPredefinedTag', () => {
+    it('returns true for predefined tag IDs', () => {
+      expect(isPredefinedTag('breakfast')).toBe(true);
+      expect(isPredefinedTag('vegetarian')).toBe(true);
+      expect(isPredefinedTag('italian')).toBe(true);
+      expect(isPredefinedTag('quick')).toBe(true);
+    });
+
+    it('returns false for custom tag IDs', () => {
+      expect(isPredefinedTag('my-custom-tag')).toBe(false);
+      expect(isPredefinedTag('random-tag')).toBe(false);
+      expect(isPredefinedTag('')).toBe(false);
+    });
+  });
+
+  describe('getTagCategory', () => {
+    it('returns category for predefined tags', () => {
+      expect(getTagCategory('breakfast')).toBe('meal');
+      expect(getTagCategory('vegetarian')).toBe('diet');
+      expect(getTagCategory('italian')).toBe('cuisine');
+      expect(getTagCategory('salads')).toBe('category');
+      expect(getTagCategory('quick')).toBe('effort');
+    });
+
+    it('returns undefined for custom tags', () => {
+      expect(getTagCategory('my-custom-tag')).toBeUndefined();
+      expect(getTagCategory('random')).toBeUndefined();
+    });
+  });
+
+  describe('getTagColorClass', () => {
+    it('returns category color for predefined tags', () => {
+      const mealColor = getTagColorClass('breakfast');
+      expect(mealColor).toBe(CATEGORY_COLORS.meal);
+
+      const dietColor = getTagColorClass('vegetarian');
+      expect(dietColor).toBe(CATEGORY_COLORS.diet);
+    });
+
+    it('returns emerald color for custom tags', () => {
+      const customColor = getTagColorClass('my-custom-tag');
+      expect(customColor).toBe('bg-emerald-500/10 text-emerald-400');
+    });
+  });
+
+  describe('getGroupedPredefinedTags', () => {
+    it('returns tags grouped by category in order', () => {
+      const grouped = getGroupedPredefinedTags();
+
+      // Should have entries for each category
+      expect(grouped.length).toBe(TAG_CATEGORY_ORDER.length);
+
+      // Categories should be in order
+      for (let i = 0; i < TAG_CATEGORY_ORDER.length; i++) {
+        expect(grouped[i][0]).toBe(TAG_CATEGORY_ORDER[i]);
+      }
+    });
+
+    it('each group contains only tags of that category', () => {
+      const grouped = getGroupedPredefinedTags();
+
+      for (const [category, tags] of grouped) {
+        for (const tag of tags) {
+          expect(tag.category).toBe(category);
+        }
+      }
+    });
+
+    it('total tags across groups equals total predefined tags', () => {
+      const grouped = getGroupedPredefinedTags();
+      const totalTags = grouped.reduce((sum, [, tags]) => sum + tags.length, 0);
+      expect(totalTags).toBe(PREDEFINED_TAGS.length);
+    });
+  });
+});

--- a/src/lib/predefined-tags.ts
+++ b/src/lib/predefined-tags.ts
@@ -1,0 +1,176 @@
+/**
+ * Predefined tag system for recipe categorization
+ *
+ * Tags are organized into categories for better UX:
+ * - meal: Meal type (breakfast, lunch, dinner, etc.)
+ * - diet: Dietary preferences (vegetarian, vegan, keto, etc.)
+ * - cuisine: Cuisine type (German, Italian, Asian, etc.)
+ * - category: Recipe category (salads, meats, soups, etc.)
+ * - effort: Effort level (quick, easy, meal-prep, etc.)
+ */
+
+export type TagCategory = 'meal' | 'diet' | 'cuisine' | 'category' | 'effort';
+
+export interface PredefinedTag {
+  /** Unique identifier stored in database (lowercase, hyphenated) */
+  id: string;
+  /** Display label (German) */
+  label: string;
+  /** English label for fallback/translation */
+  labelEn: string;
+  /** Category for grouping */
+  category: TagCategory;
+}
+
+export interface TagCategoryInfo {
+  label: string;
+  labelEn: string;
+}
+
+export const TAG_CATEGORIES: Record<TagCategory, TagCategoryInfo> = {
+  meal: { label: 'Mahlzeit', labelEn: 'Meal type' },
+  diet: { label: 'Ernährung', labelEn: 'Diet' },
+  cuisine: { label: 'Küche', labelEn: 'Cuisine' },
+  category: { label: 'Kategorie', labelEn: 'Category' },
+  effort: { label: 'Aufwand', labelEn: 'Effort' },
+};
+
+/**
+ * Category display order for consistent UI
+ */
+export const TAG_CATEGORY_ORDER: TagCategory[] = [
+  'meal',
+  'diet',
+  'cuisine',
+  'category',
+  'effort',
+];
+
+/**
+ * Category-specific colors for tag display
+ * Each category has a unique color to help users visually distinguish tags
+ */
+export const CATEGORY_COLORS: Record<TagCategory, string> = {
+  meal: 'bg-blue-500/10 text-blue-400',
+  diet: 'bg-green-500/10 text-green-400',
+  cuisine: 'bg-orange-500/10 text-orange-400',
+  category: 'bg-purple-500/10 text-purple-400',
+  effort: 'bg-yellow-500/10 text-yellow-400',
+};
+
+/**
+ * All predefined tags organized by category
+ */
+export const PREDEFINED_TAGS: PredefinedTag[] = [
+  // Meal type
+  { id: 'breakfast', label: 'Frühstück', labelEn: 'Breakfast', category: 'meal' },
+  { id: 'lunch', label: 'Mittagessen', labelEn: 'Lunch', category: 'meal' },
+  { id: 'dinner', label: 'Abendessen', labelEn: 'Dinner', category: 'meal' },
+  { id: 'snack', label: 'Snack', labelEn: 'Snack', category: 'meal' },
+  { id: 'dessert', label: 'Dessert', labelEn: 'Dessert', category: 'meal' },
+
+  // Diet
+  { id: 'vegetarian', label: 'Vegetarisch', labelEn: 'Vegetarian', category: 'diet' },
+  { id: 'vegan', label: 'Vegan', labelEn: 'Vegan', category: 'diet' },
+  { id: 'keto', label: 'Keto', labelEn: 'Keto', category: 'diet' },
+  { id: 'paleo', label: 'Paleo', labelEn: 'Paleo', category: 'diet' },
+  { id: 'high-protein', label: 'Proteinreich', labelEn: 'High-Protein', category: 'diet' },
+  { id: 'low-carb', label: 'Low-Carb', labelEn: 'Low-Carb', category: 'diet' },
+
+  // Cuisine
+  { id: 'german', label: 'Deutsch', labelEn: 'German', category: 'cuisine' },
+  { id: 'italian', label: 'Italienisch', labelEn: 'Italian', category: 'cuisine' },
+  { id: 'asian', label: 'Asiatisch', labelEn: 'Asian', category: 'cuisine' },
+  { id: 'mexican', label: 'Mexikanisch', labelEn: 'Mexican', category: 'cuisine' },
+  { id: 'mediterranean', label: 'Mediterran', labelEn: 'Mediterranean', category: 'cuisine' },
+
+  // Category
+  { id: 'salads', label: 'Salate', labelEn: 'Salads', category: 'category' },
+  { id: 'meats', label: 'Fleischgerichte', labelEn: 'Meats', category: 'category' },
+  { id: 'noodles', label: 'Nudelgerichte', labelEn: 'Noodles', category: 'category' },
+  { id: 'soups', label: 'Suppen', labelEn: 'Soups', category: 'category' },
+  { id: 'baked', label: 'Backwaren', labelEn: 'Baked', category: 'category' },
+  { id: 'drinks', label: 'Getränke', labelEn: 'Drinks', category: 'category' },
+
+  // Effort
+  { id: 'quick', label: 'Schnell', labelEn: 'Quick', category: 'effort' },
+  { id: 'easy', label: 'Einfach', labelEn: 'Easy', category: 'effort' },
+  { id: 'meal-prep', label: 'Meal-Prep', labelEn: 'Meal-Prep', category: 'effort' },
+  { id: 'weekend-project', label: 'Wochenendprojekt', labelEn: 'Weekend-Project', category: 'effort' },
+];
+
+// Pre-computed lookup map for O(1) access
+const tagByIdMap = new Map<string, PredefinedTag>(
+  PREDEFINED_TAGS.map(tag => [tag.id, tag])
+);
+
+// Pre-computed set for O(1) membership check
+const predefinedTagIdSet = new Set<string>(PREDEFINED_TAGS.map(t => t.id));
+
+/**
+ * Get all predefined tag IDs
+ */
+export function getPredefinedTagIds(): string[] {
+  return PREDEFINED_TAGS.map(t => t.id);
+}
+
+/**
+ * Get a predefined tag by its ID
+ * @param id Tag ID to look up
+ * @returns PredefinedTag if found, undefined otherwise
+ */
+export function getTagById(id: string): PredefinedTag | undefined {
+  return tagByIdMap.get(id);
+}
+
+/**
+ * Get all predefined tags in a specific category
+ * @param category Category to filter by
+ * @returns Array of tags in that category
+ */
+export function getTagsByCategory(category: TagCategory): PredefinedTag[] {
+  return PREDEFINED_TAGS.filter(t => t.category === category);
+}
+
+/**
+ * Check if a tag ID is a predefined tag
+ * @param id Tag ID to check
+ * @returns true if predefined, false if custom
+ */
+export function isPredefinedTag(id: string): boolean {
+  return predefinedTagIdSet.has(id);
+}
+
+/**
+ * Get the category of a tag (predefined or custom)
+ * @param id Tag ID
+ * @returns TagCategory if predefined, undefined if custom
+ */
+export function getTagCategory(id: string): TagCategory | undefined {
+  return tagByIdMap.get(id)?.category;
+}
+
+/**
+ * Get the display color class for a tag
+ * @param id Tag ID
+ * @returns Tailwind color classes, defaults to emerald for custom tags
+ */
+export function getTagColorClass(id: string): string {
+  const category = getTagCategory(id);
+  if (category) {
+    return CATEGORY_COLORS[category];
+  }
+  // Default color for custom tags
+  return 'bg-emerald-500/10 text-emerald-400';
+}
+
+/**
+ * Get grouped predefined tags by category in display order
+ * @returns Array of [category, tags] tuples
+ */
+export function getGroupedPredefinedTags(): [TagCategory, PredefinedTag[]][] {
+  return TAG_CATEGORY_ORDER.map(category => [
+    category,
+    getTagsByCategory(category),
+  ]);
+}


### PR DESCRIPTION
## Summary
- Add predefined tag system with 26 tags across 5 categories (meal, diet, cuisine, category, effort)
- Create `/api/recipes/tags` endpoint for fetching all available tags
- Enhance TagInput dropdown with category-grouped predefined tags
- Add category-based coloring for tags in cards and filter chips
- Display German labels for predefined tags with English IDs stored in database

## Test plan
- [ ] Navigate to `/recipes/new` and verify predefined tags appear in dropdown grouped by category
- [ ] Select a predefined tag and verify it's added to the recipe
- [ ] Type to filter tags and verify search works across ID, German label, and English label
- [ ] Add a custom tag and verify it appears under "Your tags"
- [ ] View recipes list and verify tags display with category colors
- [ ] Click a tag filter chip and verify filtering works correctly

## Screenshots
The TagInput now shows predefined tags first, organized by category:

| Category | Color | Tags |
|----------|-------|------|
| Mahlzeit (Meal) | Blue | Frühstück, Mittagessen, Abendessen, Snack, Dessert |
| Ernährung (Diet) | Green | Vegetarisch, Vegan, Keto, Paleo, Proteinreich, Low-Carb |
| Küche (Cuisine) | Orange | Deutsch, Italienisch, Asiatisch, Mexikanisch, Mediterran |
| Kategorie (Category) | Purple | Salate, Fleischgerichte, Nudelgerichte, Suppen, Backwaren, Getränke |
| Aufwand (Effort) | Yellow | Schnell, Einfach, Meal-Prep, Wochenendprojekt |

Closes #68

🤖 Generated with [Claude Code](https://claude.ai/claude-code)