### PR TITLE
feat: add recipe photo capture/upload UI

### DIFF
--- a/e2e/recipes.spec.ts
+++ b/e2e/recipes.spec.ts
@@ -289,6 +289,95 @@ test.describe('Recipe Feature', () => {
     });
   });
 
+  test.describe('Photo Capture Modal', () => {
+    test('shows camera button on recipes page', async ({ authenticatedPage }) => {
+      await authenticatedPage.goto('/recipes');
+
+      // Camera button should be visible
+      const cameraButton = authenticatedPage.getByRole('button', { name: /import recipe from photo/i });
+      await expect(cameraButton).toBeVisible();
+    });
+
+    test('opens photo capture modal when camera button is clicked', async ({ authenticatedPage }) => {
+      await authenticatedPage.goto('/recipes');
+
+      // Click camera button
+      const cameraButton = authenticatedPage.getByRole('button', { name: /import recipe from photo/i });
+      await cameraButton.click();
+
+      // Modal should open with "Import Recipe" heading
+      await expect(authenticatedPage.getByRole('heading', { name: 'Import Recipe' })).toBeVisible();
+    });
+
+    test('modal has cancel button', async ({ authenticatedPage }) => {
+      await authenticatedPage.goto('/recipes');
+
+      // Open modal
+      const cameraButton = authenticatedPage.getByRole('button', { name: /import recipe from photo/i });
+      await cameraButton.click();
+
+      // Cancel button should be visible
+      await expect(authenticatedPage.getByRole('button', { name: /cancel/i })).toBeVisible();
+    });
+
+    test('modal closes when cancel is clicked', async ({ authenticatedPage }) => {
+      await authenticatedPage.goto('/recipes');
+
+      // Open modal
+      const cameraButton = authenticatedPage.getByRole('button', { name: /import recipe from photo/i });
+      await cameraButton.click();
+
+      // Click cancel
+      const cancelButton = authenticatedPage.getByRole('button', { name: /cancel/i });
+      await cancelButton.click();
+
+      // Modal should close - heading should not be visible
+      await expect(authenticatedPage.getByRole('heading', { name: 'Import Recipe' })).not.toBeVisible();
+    });
+
+    test('modal closes when close button is clicked', async ({ authenticatedPage }) => {
+      await authenticatedPage.goto('/recipes');
+
+      // Open modal
+      const cameraButton = authenticatedPage.getByRole('button', { name: /import recipe from photo/i });
+      await cameraButton.click();
+
+      // Click close button (×)
+      const closeButton = authenticatedPage.getByLabel('Close');
+      await closeButton.click();
+
+      // Modal should close
+      await expect(authenticatedPage.getByRole('heading', { name: 'Import Recipe' })).not.toBeVisible();
+    });
+
+    test('desktop view shows upload/drop zone', async ({ authenticatedPage }) => {
+      // Set viewport to desktop size
+      await authenticatedPage.setViewportSize({ width: 1024, height: 768 });
+      await authenticatedPage.goto('/recipes');
+
+      // Open modal
+      const cameraButton = authenticatedPage.getByRole('button', { name: /import recipe from photo/i });
+      await cameraButton.click();
+
+      // Should show drop zone text
+      await expect(authenticatedPage.getByText(/drop image here/i)).toBeVisible();
+    });
+
+    test('mobile view shows camera and library buttons', async ({ authenticatedPage }) => {
+      // Set viewport to mobile size
+      await authenticatedPage.setViewportSize({ width: 375, height: 667 });
+      await authenticatedPage.goto('/recipes');
+
+      // Open modal
+      const cameraButton = authenticatedPage.getByRole('button', { name: /import recipe from photo/i });
+      await cameraButton.click();
+
+      // Should show camera and library buttons
+      await expect(authenticatedPage.getByText('Take Photo')).toBeVisible();
+      await expect(authenticatedPage.getByText('Choose from Library')).toBeVisible();
+    });
+  });
+
   test.describe('Bottom Navigation', () => {
     test('shows bottom nav on recipes list page', async ({ authenticatedPage }) => {
       await authenticatedPage.goto('/recipes');

--- a/src/app/recipes/new/page.tsx
+++ b/src/app/recipes/new/page.tsx
@@ -8,7 +8,11 @@ import { PREDEFINED_TAGS, TAG_CATEGORIES } from '@/lib/predefined-tags';
 
 export const dynamic = 'force-dynamic';
 
-export default async function NewRecipePage() {
+export default async function NewRecipePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ image?: string }>;
+}) {
   const session = await auth();
   if (!session?.user) {
     redirect('/login');
@@ -19,6 +23,10 @@ export default async function NewRecipePage() {
 
   // Get existing tags for autocomplete
   const existingTags = await getUserTags();
+
+  // Get initial image URL from search params (if redirected from photo capture)
+  const params = await searchParams;
+  const initialImageUrl = params.image;
 
   return (
     <main className="min-h-screen bg-slate-950 text-slate-100">
@@ -47,6 +55,7 @@ export default async function NewRecipePage() {
           predefinedTags={PREDEFINED_TAGS}
           tagCategories={TAG_CATEGORIES}
           defaultLocale={userLocale}
+          initialImageUrl={initialImageUrl}
         />
       </div>
     </main>

--- a/src/app/recipes/page.tsx
+++ b/src/app/recipes/page.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { redirect } from "next/navigation";
 import { Suspense } from "react";
 
@@ -6,25 +5,10 @@ import { auth } from "@/lib/auth";
 import { getUserRecipeSummaries, getUserTags } from "@/lib/recipes";
 import { LogoutButton } from "@/components/LogoutButton";
 import { RecipeListClient } from "@/components/RecipeListClient";
+import { RecipePageHeader } from "@/components/RecipePageHeader";
 import { PREDEFINED_TAGS } from "@/lib/predefined-tags";
 
 export const dynamic = "force-dynamic";
-
-const PlusIcon = () => (
-  <svg
-    className="h-4 w-4"
-    fill="none"
-    stroke="currentColor"
-    viewBox="0 0 24 24"
-  >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth={2}
-      d="M12 4v16m8-8H4"
-    />
-  </svg>
-);
 
 export default async function RecipesPage() {
   const session = await auth();
@@ -49,19 +33,8 @@ export default async function RecipesPage() {
           <LogoutButton />
         </header>
 
-        {/* Title section with Add button */}
-        <section className="flex items-center justify-between">
-          <h1 className="text-2xl font-semibold text-white sm:text-3xl">
-            Recipes
-          </h1>
-          <Link
-            href="/recipes/new"
-            className="inline-flex items-center gap-2 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-medium text-slate-950 transition hover:bg-emerald-400"
-          >
-            <PlusIcon />
-            Add Recipe
-          </Link>
-        </section>
+        {/* Title section with Add and Camera buttons */}
+        <RecipePageHeader />
 
         {/* Search, filter, and recipe list - wrapped in Suspense for useSearchParams */}
         <Suspense fallback={<RecipeListSkeleton />}>

--- a/src/components/PhotoCaptureModal.tsx
+++ b/src/components/PhotoCaptureModal.tsx
@@ -1,0 +1,408 @@
+'use client';
+
+import { useState, useRef, useCallback, useEffect } from 'react';
+import Image from 'next/image';
+import { validateImageFile, resizeImage, MAX_FILE_SIZE_MB } from '@/lib/image-utils';
+
+interface PhotoCaptureModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onImageCaptured: (imageUrl: string) => void;
+}
+
+const CameraIcon = () => (
+  <svg className="h-8 w-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z"
+    />
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M15 13a3 3 0 11-6 0 3 3 0 016 0z"
+    />
+  </svg>
+);
+
+const GalleryIcon = () => (
+  <svg className="h-8 w-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+    />
+  </svg>
+);
+
+const UploadIcon = () => (
+  <svg className="mx-auto h-12 w-12 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={1.5}
+      d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+    />
+  </svg>
+);
+
+export function PhotoCaptureModal({ isOpen, onClose, onImageCaptured }: PhotoCaptureModalProps) {
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [dragOver, setDragOver] = useState(false);
+  const [isDesktop, setIsDesktop] = useState(false);
+
+  const cameraInputRef = useRef<HTMLInputElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Detect desktop breakpoint (md: 768px)
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const mediaQuery = window.matchMedia('(min-width: 768px)');
+    setIsDesktop(mediaQuery.matches);
+
+    const handleChange = (e: MediaQueryListEvent) => {
+      setIsDesktop(e.matches);
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  // Cleanup preview URL on unmount or when file changes
+  useEffect(() => {
+    return () => {
+      if (previewUrl) {
+        URL.revokeObjectURL(previewUrl);
+      }
+    };
+  }, [previewUrl]);
+
+  // Reset state when modal closes
+  useEffect(() => {
+    if (!isOpen) {
+      setSelectedFile(null);
+      if (previewUrl) {
+        URL.revokeObjectURL(previewUrl);
+        setPreviewUrl(null);
+      }
+      setError(null);
+      setIsUploading(false);
+      setDragOver(false);
+    }
+  }, [isOpen, previewUrl]);
+
+  const handleFileSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    // Reset input so same file can be selected again
+    e.target.value = '';
+
+    setError(null);
+
+    // Validate file
+    const validation = validateImageFile(file);
+    if (!validation.valid) {
+      setError(validation.error || 'Invalid file');
+      return;
+    }
+
+    // Create preview
+    const url = URL.createObjectURL(file);
+    if (previewUrl) {
+      URL.revokeObjectURL(previewUrl);
+    }
+    setPreviewUrl(url);
+    setSelectedFile(file);
+  }, [previewUrl]);
+
+  const handleDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setDragOver(false);
+
+    const file = e.dataTransfer.files[0];
+    if (!file) return;
+
+    setError(null);
+
+    // Validate file
+    const validation = validateImageFile(file);
+    if (!validation.valid) {
+      setError(validation.error || 'Invalid file');
+      return;
+    }
+
+    // Create preview
+    const url = URL.createObjectURL(file);
+    if (previewUrl) {
+      URL.revokeObjectURL(previewUrl);
+    }
+    setPreviewUrl(url);
+    setSelectedFile(file);
+  }, [previewUrl]);
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setDragOver(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setDragOver(false);
+  }, []);
+
+  const handleReset = useCallback(() => {
+    if (previewUrl) {
+      URL.revokeObjectURL(previewUrl);
+    }
+    setPreviewUrl(null);
+    setSelectedFile(null);
+    setError(null);
+  }, [previewUrl]);
+
+  const handleExtractRecipe = useCallback(async () => {
+    if (!selectedFile) return;
+
+    setIsUploading(true);
+    setError(null);
+
+    try {
+      // Resize image client-side
+      const resizedBlob = await resizeImage(selectedFile);
+
+      // Upload to server
+      const formData = new FormData();
+      formData.append('image', resizedBlob, `recipe-photo.jpg`);
+
+      const response = await fetch('/api/recipes/images/upload', {
+        method: 'POST',
+        body: formData,
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || 'Upload failed');
+      }
+
+      const data = await response.json();
+
+      // Notify parent with the uploaded image URL
+      onImageCaptured(data.url);
+    } catch (err) {
+      console.error('Upload error:', err);
+      setError(err instanceof Error ? err.message : 'Upload failed');
+    } finally {
+      setIsUploading(false);
+    }
+  }, [selectedFile, onImageCaptured]);
+
+  const formatFileSize = (bytes: number): string => {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  };
+
+  if (!isOpen) return null;
+
+  const hasPreview = Boolean(previewUrl && selectedFile);
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/50 z-50"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Modal */}
+      <div
+        className={`fixed z-50 bg-slate-900 flex flex-col
+          inset-x-0 bottom-0 rounded-t-2xl max-h-[90vh]
+          md:inset-auto md:top-1/2 md:left-1/2 md:-translate-x-1/2 md:-translate-y-1/2
+          md:w-[500px] md:max-h-[80vh] md:rounded-xl md:border md:border-slate-700`}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-slate-700">
+          <h2 className="text-lg font-semibold">
+            {hasPreview ? 'Review Photo' : 'Import Recipe'}
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-slate-400 hover:text-white text-2xl leading-none"
+            aria-label="Close"
+          >
+            &times;
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto p-4">
+          {/* Error message */}
+          {error && (
+            <div className="bg-red-500/20 text-red-200 p-3 rounded text-sm mb-4">
+              {error}
+            </div>
+          )}
+
+          {hasPreview ? (
+            // Preview step
+            <div className="space-y-4">
+              {/* Image preview */}
+              <div className="relative aspect-[4/3] rounded-lg overflow-hidden bg-slate-800">
+                <Image
+                  src={previewUrl!}
+                  alt="Recipe preview"
+                  fill
+                  className="object-contain"
+                  unoptimized
+                />
+                {isUploading && (
+                  <div className="absolute inset-0 bg-black/50 flex items-center justify-center">
+                    <div className="text-center">
+                      <div className="w-12 h-12 border-4 border-emerald-500 border-t-transparent rounded-full animate-spin mx-auto mb-2" />
+                      <p className="text-sm text-white">Uploading...</p>
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {/* File info */}
+              <div className="text-sm text-slate-400">
+                <p>{selectedFile!.name}</p>
+                <p>{formatFileSize(selectedFile!.size)}</p>
+                {selectedFile!.size > MAX_FILE_SIZE_MB * 0.8 * 1024 * 1024 && (
+                  <p className="text-amber-400 mt-1">
+                    Large file - will be resized before upload
+                  </p>
+                )}
+              </div>
+
+              {/* Action buttons */}
+              <div className="flex flex-col gap-3 pt-2">
+                <button
+                  onClick={handleExtractRecipe}
+                  disabled={isUploading}
+                  className="w-full py-3 bg-emerald-500 hover:bg-emerald-400 text-slate-950 rounded-xl font-medium transition disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {isUploading ? 'Uploading...' : 'Import Recipe'}
+                </button>
+                <button
+                  onClick={handleReset}
+                  disabled={isUploading}
+                  className="w-full py-3 bg-slate-700 hover:bg-slate-600 rounded-xl font-medium transition disabled:opacity-50"
+                >
+                  Choose Different Photo
+                </button>
+                <button
+                  onClick={onClose}
+                  disabled={isUploading}
+                  className="text-slate-400 hover:text-white py-2 transition disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : isDesktop ? (
+            // Desktop: Upload/drag-drop zone
+            <div className="space-y-4">
+              <div
+                onDrop={handleDrop}
+                onDragOver={handleDragOver}
+                onDragLeave={handleDragLeave}
+                onClick={() => fileInputRef.current?.click()}
+                className={`
+                  border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition
+                  ${dragOver
+                    ? 'border-emerald-500 bg-emerald-500/10'
+                    : 'border-slate-700 hover:border-slate-600'
+                  }
+                `}
+              >
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp,image/gif,image/heic,image/heif"
+                  onChange={handleFileSelect}
+                  className="hidden"
+                />
+                <div className="text-slate-400">
+                  <UploadIcon />
+                  <p className="text-sm">
+                    Drop image here or <span className="text-emerald-400">browse</span>
+                  </p>
+                  <p className="text-xs mt-2 text-slate-500">
+                    JPEG, PNG, WebP, GIF, HEIC up to {MAX_FILE_SIZE_MB}MB
+                  </p>
+                </div>
+              </div>
+
+              <button
+                onClick={onClose}
+                className="w-full text-slate-400 hover:text-white py-2 transition"
+              >
+                Cancel
+              </button>
+            </div>
+          ) : (
+            // Mobile: Camera and library buttons
+            <div className="space-y-4">
+              {/* Hidden inputs */}
+              <input
+                ref={cameraInputRef}
+                type="file"
+                accept="image/jpeg,image/png,image/webp,image/gif,image/heic,image/heif"
+                capture="environment"
+                onChange={handleFileSelect}
+                className="hidden"
+              />
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/jpeg,image/png,image/webp,image/gif,image/heic,image/heif"
+                onChange={handleFileSelect}
+                className="hidden"
+              />
+
+              {/* Take photo button */}
+              <button
+                onClick={() => cameraInputRef.current?.click()}
+                className="w-full flex items-center justify-center gap-3 py-6 bg-slate-800 hover:bg-slate-700 rounded-xl transition"
+              >
+                <CameraIcon />
+                <span className="font-medium">Take Photo</span>
+              </button>
+
+              {/* Choose from library button */}
+              <button
+                onClick={() => fileInputRef.current?.click()}
+                className="w-full flex items-center justify-center gap-3 py-6 bg-slate-800 hover:bg-slate-700 rounded-xl transition"
+              >
+                <GalleryIcon />
+                <span className="font-medium">Choose from Library</span>
+              </button>
+
+              <p className="text-xs text-center text-slate-500">
+                JPEG, PNG, WebP, GIF, HEIC up to {MAX_FILE_SIZE_MB}MB
+              </p>
+
+              <button
+                onClick={onClose}
+                className="w-full text-slate-400 hover:text-white py-2 transition"
+              >
+                Cancel
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/RecipeForm.tsx
+++ b/src/components/RecipeForm.tsx
@@ -29,6 +29,8 @@ interface RecipeFormProps {
   tagCategories?: Partial<Record<TagCategory, TagCategoryInfo>>;
   /** Default locale for new recipes (from user preferences) */
   defaultLocale?: string;
+  /** Initial image URL (from photo capture redirect) */
+  initialImageUrl?: string;
 }
 
 interface FormState {
@@ -71,6 +73,7 @@ export function RecipeForm({
   predefinedTags = [],
   tagCategories = {},
   defaultLocale = 'en-US',
+  initialImageUrl,
 }: RecipeFormProps) {
   const router = useRouter();
   const isEditing = Boolean(slug);
@@ -88,6 +91,13 @@ export function RecipeForm({
         ingredientGroups: initialRecipe.ingredientGroups,
         steps: initialRecipe.steps,
         images: initialRecipe.images,
+      };
+    }
+    // If initialImageUrl is provided (from photo capture), pre-populate images
+    if (initialImageUrl) {
+      return {
+        ...DEFAULT_FORM_STATE,
+        images: [{ url: initialImageUrl, isPrimary: true }],
       };
     }
     return DEFAULT_FORM_STATE;

--- a/src/components/RecipePageHeader.tsx
+++ b/src/components/RecipePageHeader.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { PhotoCaptureModal } from './PhotoCaptureModal';
+
+const PlusIcon = () => (
+  <svg
+    className="h-4 w-4"
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M12 4v16m8-8H4"
+    />
+  </svg>
+);
+
+const CameraIcon = () => (
+  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z"
+    />
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M15 13a3 3 0 11-6 0 3 3 0 016 0z"
+    />
+  </svg>
+);
+
+export function RecipePageHeader() {
+  const router = useRouter();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleImageCaptured = (imageUrl: string) => {
+    setIsModalOpen(false);
+    // Navigate to new recipe form with pre-filled image
+    router.push(`/recipes/new?image=${encodeURIComponent(imageUrl)}`);
+  };
+
+  return (
+    <>
+      <section className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold text-white sm:text-3xl">
+          Recipes
+        </h1>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setIsModalOpen(true)}
+            className="inline-flex items-center justify-center rounded-xl bg-slate-700 p-2.5 text-slate-100 transition hover:bg-slate-600"
+            aria-label="Import recipe from photo"
+            title="Import from photo"
+          >
+            <CameraIcon />
+          </button>
+          <Link
+            href="/recipes/new"
+            className="inline-flex items-center gap-2 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-medium text-slate-950 transition hover:bg-emerald-400"
+          >
+            <PlusIcon />
+            Add Recipe
+          </Link>
+        </div>
+      </section>
+
+      <PhotoCaptureModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onImageCaptured={handleImageCaptured}
+      />
+    </>
+  );
+}

--- a/src/components/__tests__/PhotoCaptureModal.test.tsx
+++ b/src/components/__tests__/PhotoCaptureModal.test.tsx
@@ -1,0 +1,408 @@
+/**
+ * Tests for PhotoCaptureModal component
+ */
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { PhotoCaptureModal } from '../PhotoCaptureModal';
+
+// Mock next/image
+vi.mock('next/image', () => ({
+  default: ({
+    src,
+    alt,
+    className,
+  }: {
+    src: string;
+    alt: string;
+    className?: string;
+  }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src={src} alt={alt} className={className} data-testid="preview-image" />
+  ),
+}));
+
+// Mock image-utils
+vi.mock('@/lib/image-utils', () => ({
+  validateImageFile: vi.fn(() => ({ valid: true })),
+  resizeImage: vi.fn(() => Promise.resolve(new Blob(['test'], { type: 'image/jpeg' }))),
+  MAX_FILE_SIZE_MB: 10,
+}));
+
+import { validateImageFile } from '@/lib/image-utils';
+
+// Mock URL.createObjectURL and revokeObjectURL
+const mockCreateObjectURL = vi.fn(() => 'blob:mock-url');
+const mockRevokeObjectURL = vi.fn();
+global.URL.createObjectURL = mockCreateObjectURL;
+global.URL.revokeObjectURL = mockRevokeObjectURL;
+
+// Mock fetch
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+// Mock matchMedia for responsive design
+const mockMatchMedia = vi.fn();
+window.matchMedia = mockMatchMedia;
+
+describe('PhotoCaptureModal', () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    onImageCaptured: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ url: '/api/recipes/images/user1/captured-image' }),
+    });
+    // Default to desktop view
+    mockMatchMedia.mockReturnValue({
+      matches: true, // isDesktop = true
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('renders when isOpen is true', () => {
+      render(<PhotoCaptureModal {...defaultProps} />);
+      expect(screen.getByText('Import Recipe')).toBeInTheDocument();
+    });
+
+    it('does not render when isOpen is false', () => {
+      render(<PhotoCaptureModal {...defaultProps} isOpen={false} />);
+      expect(screen.queryByText('Import Recipe')).not.toBeInTheDocument();
+    });
+
+    it('renders desktop view with drop zone', () => {
+      mockMatchMedia.mockReturnValue({
+        matches: true,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      });
+      render(<PhotoCaptureModal {...defaultProps} />);
+      expect(screen.getByText(/drop image here/i)).toBeInTheDocument();
+    });
+
+    it('renders mobile view with camera and library buttons', () => {
+      mockMatchMedia.mockReturnValue({
+        matches: false, // isDesktop = false
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      });
+      render(<PhotoCaptureModal {...defaultProps} />);
+      expect(screen.getByText('Take Photo')).toBeInTheDocument();
+      expect(screen.getByText('Choose from Library')).toBeInTheDocument();
+    });
+
+    it('renders cancel button', () => {
+      render(<PhotoCaptureModal {...defaultProps} />);
+      expect(screen.getByText('Cancel')).toBeInTheDocument();
+    });
+  });
+
+  describe('file selection', () => {
+    it('shows preview after file selection', async () => {
+      const user = userEvent.setup();
+      render(<PhotoCaptureModal {...defaultProps} />);
+
+      const file = new File(['test'], 'recipe.jpg', { type: 'image/jpeg' });
+      const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+      await user.upload(input, file);
+
+      await waitFor(() => {
+        expect(screen.getByText('Review Photo')).toBeInTheDocument();
+        expect(screen.getByTestId('preview-image')).toBeInTheDocument();
+      });
+    });
+
+    it('shows file name and size in preview', async () => {
+      const user = userEvent.setup();
+      render(<PhotoCaptureModal {...defaultProps} />);
+
+      const file = new File(['test content'], 'my-recipe.jpg', { type: 'image/jpeg' });
+      const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+      await user.upload(input, file);
+
+      await waitFor(() => {
+        expect(screen.getByText('my-recipe.jpg')).toBeInTheDocument();
+      });
+    });
+
+    it('shows error for invalid file type', async () => {
+      const user = userEvent.setup();
+
+      // Override mock before render
+      vi.mocked(validateImageFile).mockReturnValue({
+        valid: false,
+        error: 'Invalid file type. Allowed: JPEG, PNG, WebP, GIF, HEIC',
+      });
+
+      render(<PhotoCaptureModal {...defaultProps} />);
+
+      const file = new File(['test'], 'test.jpg', { type: 'image/jpeg' });
+      const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+      await user.upload(input, file);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Invalid file type/i)).toBeInTheDocument();
+      });
+
+      // Reset mock for other tests
+      vi.mocked(validateImageFile).mockReturnValue({ valid: true });
+    });
+  });
+
+  describe('preview actions', () => {
+    async function setupPreview() {
+      const user = userEvent.setup();
+      render(<PhotoCaptureModal {...defaultProps} />);
+
+      const file = new File(['test'], 'recipe.jpg', { type: 'image/jpeg' });
+      const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+      await user.upload(input, file);
+
+      await waitFor(() => {
+        expect(screen.getByText('Review Photo')).toBeInTheDocument();
+      });
+
+      return user;
+    }
+
+    it('shows Import Recipe button in preview', async () => {
+      const user = await setupPreview();
+      // Verify we have the button - look for button that contains "Import Recipe" text
+      const importButton = screen.getByRole('button', { name: /import recipe/i });
+      expect(importButton).toBeInTheDocument();
+      // Verify button is not disabled
+      expect(importButton).not.toBeDisabled();
+    });
+
+    it('shows Choose Different Photo button in preview', async () => {
+      await setupPreview();
+      expect(screen.getByRole('button', { name: /choose different photo/i })).toBeInTheDocument();
+    });
+
+    it('resets to initial view when Choose Different Photo is clicked', async () => {
+      const user = await setupPreview();
+
+      await user.click(screen.getByRole('button', { name: /choose different photo/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Import Recipe')).toBeInTheDocument();
+        expect(screen.queryByTestId('preview-image')).not.toBeInTheDocument();
+      });
+    });
+
+    it('revokes object URL when resetting', async () => {
+      const user = await setupPreview();
+
+      await user.click(screen.getByRole('button', { name: /choose different photo/i }));
+
+      expect(mockRevokeObjectURL).toHaveBeenCalled();
+    });
+  });
+
+  describe('upload and callback', () => {
+    it('calls onImageCaptured with URL after successful upload', async () => {
+      const onImageCaptured = vi.fn();
+      const user = userEvent.setup();
+      render(<PhotoCaptureModal {...defaultProps} onImageCaptured={onImageCaptured} />);
+
+      const file = new File(['test'], 'recipe.jpg', { type: 'image/jpeg' });
+      const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+      await user.upload(input, file);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /import recipe/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /import recipe/i }));
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          '/api/recipes/images/upload',
+          expect.objectContaining({ method: 'POST' })
+        );
+        expect(onImageCaptured).toHaveBeenCalledWith('/api/recipes/images/user1/captured-image');
+      });
+    });
+
+    it('shows loading state during upload', async () => {
+      // Make fetch take some time
+      mockFetch.mockImplementationOnce(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(
+              () =>
+                resolve({
+                  ok: true,
+                  json: () => Promise.resolve({ url: '/api/recipes/images/user1/new' }),
+                }),
+              100
+            )
+          )
+      );
+
+      const user = userEvent.setup();
+      render(<PhotoCaptureModal {...defaultProps} />);
+
+      const file = new File(['test'], 'recipe.jpg', { type: 'image/jpeg' });
+      const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+      await user.upload(input, file);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /import recipe/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /import recipe/i }));
+
+      // Should show uploading state - button text changes to Uploading...
+      // Use getAllByText since there are two elements with this text (button + overlay)
+      expect(screen.getAllByText('Uploading...').length).toBeGreaterThan(0);
+    });
+
+    it('shows error on upload failure', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        json: () => Promise.resolve({ error: 'Upload failed' }),
+      });
+
+      const user = userEvent.setup();
+      render(<PhotoCaptureModal {...defaultProps} />);
+
+      const file = new File(['test'], 'recipe.jpg', { type: 'image/jpeg' });
+      const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+      await user.upload(input, file);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /import recipe/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /import recipe/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/Upload failed/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('modal actions', () => {
+    it('calls onClose when close button is clicked', async () => {
+      const onClose = vi.fn();
+      const user = userEvent.setup();
+      render(<PhotoCaptureModal {...defaultProps} onClose={onClose} />);
+
+      await user.click(screen.getByLabelText('Close'));
+
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it('calls onClose when Cancel is clicked', async () => {
+      const onClose = vi.fn();
+      const user = userEvent.setup();
+      render(<PhotoCaptureModal {...defaultProps} onClose={onClose} />);
+
+      await user.click(screen.getByText('Cancel'));
+
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it('calls onClose when backdrop is clicked', async () => {
+      const onClose = vi.fn();
+      const user = userEvent.setup();
+      render(<PhotoCaptureModal {...defaultProps} onClose={onClose} />);
+
+      // Find the backdrop (the div with bg-black/50)
+      const backdrop = document.querySelector('.bg-black\\/50');
+      await user.click(backdrop!);
+
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('drag and drop (desktop)', () => {
+    beforeEach(() => {
+      mockMatchMedia.mockReturnValue({
+        matches: true, // isDesktop = true
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      });
+    });
+
+    it('shows drag over state on dragOver', () => {
+      render(<PhotoCaptureModal {...defaultProps} />);
+
+      const dropZone = screen.getByText(/drop image here/i).closest('div[class*="border-dashed"]');
+      fireEvent.dragOver(dropZone!);
+
+      expect(dropZone).toHaveClass('border-emerald-500');
+    });
+
+    it('removes drag over state on dragLeave', () => {
+      render(<PhotoCaptureModal {...defaultProps} />);
+
+      const dropZone = screen.getByText(/drop image here/i).closest('div[class*="border-dashed"]');
+      fireEvent.dragOver(dropZone!);
+      expect(dropZone).toHaveClass('border-emerald-500');
+
+      fireEvent.dragLeave(dropZone!);
+      expect(dropZone).not.toHaveClass('border-emerald-500');
+    });
+
+    // Note: Testing actual file drop behavior is challenging in JSDOM
+    // because DataTransfer.files doesn't behave like a proper FileList.
+    // The core upload flow is tested via file input selection tests.
+    // The drag-over visual feedback is tested above.
+  });
+
+  describe('mobile view', () => {
+    beforeEach(() => {
+      mockMatchMedia.mockReturnValue({
+        matches: false, // isDesktop = false
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      });
+    });
+
+    it('has camera input with capture attribute', () => {
+      render(<PhotoCaptureModal {...defaultProps} />);
+
+      const cameraInput = document.querySelector('input[capture="environment"]');
+      expect(cameraInput).toBeInTheDocument();
+    });
+
+    it('has regular file input for library', () => {
+      render(<PhotoCaptureModal {...defaultProps} />);
+
+      // There should be 2 file inputs - one with capture and one without
+      const fileInputs = document.querySelectorAll('input[type="file"]');
+      expect(fileInputs.length).toBe(2);
+
+      // One should have capture attribute, one should not
+      const withCapture = Array.from(fileInputs).filter(
+        (input) => input.hasAttribute('capture')
+      );
+      const withoutCapture = Array.from(fileInputs).filter(
+        (input) => !input.hasAttribute('capture')
+      );
+      expect(withCapture.length).toBe(1);
+      expect(withoutCapture.length).toBe(1);
+    });
+  });
+});

--- a/src/lib/__tests__/image-utils.test.ts
+++ b/src/lib/__tests__/image-utils.test.ts
@@ -199,7 +199,9 @@ describe('image-utils', () => {
       expect(ALLOWED_IMAGE_TYPES).toContain('image/png');
       expect(ALLOWED_IMAGE_TYPES).toContain('image/webp');
       expect(ALLOWED_IMAGE_TYPES).toContain('image/gif');
-      expect(ALLOWED_IMAGE_TYPES).toHaveLength(4);
+      expect(ALLOWED_IMAGE_TYPES).toContain('image/heic');
+      expect(ALLOWED_IMAGE_TYPES).toContain('image/heif');
+      expect(ALLOWED_IMAGE_TYPES).toHaveLength(6);
     });
   });
 });

--- a/src/lib/image-utils.ts
+++ b/src/lib/image-utils.ts
@@ -14,6 +14,8 @@ export const ALLOWED_IMAGE_TYPES = [
   'image/png',
   'image/webp',
   'image/gif',
+  'image/heic',
+  'image/heif',
 ];
 
 export interface ImageValidationResult {
@@ -28,7 +30,7 @@ export function validateImageFile(file: File): ImageValidationResult {
   if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
     return {
       valid: false,
-      error: `Invalid file type. Allowed: JPEG, PNG, WebP, GIF`,
+      error: `Invalid file type. Allowed: JPEG, PNG, WebP, GIF, HEIC`,
     };
   }
 


### PR DESCRIPTION
## Summary
- Add camera/photo upload UI for importing recipes
- Create PhotoCaptureModal component with responsive design (desktop: drop zone, mobile: camera/library buttons)
- Add camera button to recipes page header
- Support HEIC/HEIF image formats
- Pre-populate recipe form with uploaded image via URL parameter

This creates the UI foundation for AI-powered recipe extraction (parent issue #49).

## Files Changed
- `src/components/PhotoCaptureModal.tsx` - New modal for photo capture/upload
- `src/components/RecipePageHeader.tsx` - New client component with camera button
- `src/app/recipes/page.tsx` - Use new RecipePageHeader component
- `src/app/recipes/new/page.tsx` - Accept initial image URL from query params
- `src/components/RecipeForm.tsx` - Support initialImageUrl prop
- `src/lib/image-utils.ts` - Add HEIC/HEIF to allowed types
- `src/lib/__tests__/image-utils.test.ts` - Update tests for HEIC
- `src/components/__tests__/PhotoCaptureModal.test.tsx` - New unit tests (22 tests)
- `e2e/recipes.spec.ts` - New E2E tests (7 tests)

## Test plan
- [x] Unit tests pass (829 tests)
- [x] E2E tests for photo capture modal
- [x] Manual testing with Playwright MCP
  - [x] Desktop: Modal opens with drop zone
  - [x] Mobile: Modal shows Take Photo and Choose from Library buttons
  - [x] Cancel and close buttons work correctly
  - [x] Responsive layout switches correctly

Closes #71

🤖 Generated with [Claude Code](https://claude.ai/code)