### PR TITLE
fix: seed exercise library in production deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,4 @@ EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
 
-CMD ["sh", "-c", "npx tsx scripts/migrate.ts && node server.js"]
+CMD ["sh", "-c", "npx tsx scripts/migrate.ts && npx tsx scripts/seed-exercises.ts && node server.js"]


### PR DESCRIPTION
## Summary
- Add exercise seeding script to Dockerfile CMD, running after migrations and before server startup
- Ensures exercises are automatically seeded on every deployment without manual intervention
- The seeding script is idempotent (uses `getOrCreateExercise` which prevents duplicates)

Closes #146

## Test plan
- [x] Lint check passed
- [x] Production build succeeded
- [x] Manual testing confirmed app works correctly
- [ ] After merge: Verify exercises appear in production database

## Verification after deployment
```bash
# Check exercise count via Railway logs
railway logs | grep -i "exercise"

# Or query production database
railway run psql $DATABASE_URL -c "SELECT COUNT(*) FROM exercises;"
# Expected: 82 exercises
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)