### PR TITLE
perf: optimize GitHub Actions CI for faster test execution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,16 @@ jobs:
           node-version: 20
           cache: 'npm'
       - run: npm ci
+
+      # Cache Next.js build
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: nextjs-${{ hashFiles('package-lock.json') }}-${{ hashFiles('src/**') }}
+          restore-keys: |
+            nextjs-${{ hashFiles('package-lock.json') }}-
+
       - run: npm run lint
       - run: npm run test:unit
       - run: npm run build
@@ -26,7 +36,11 @@ jobs:
 
   e2e-tests:
     runs-on: ubuntu-latest
-    needs: unit-tests
+    # Runs in parallel with unit-tests (no needs dependency)
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     services:
       postgres:
         image: postgres:16
@@ -48,12 +62,34 @@ jobs:
           node-version: 20
           cache: 'npm'
       - run: npm ci
-      - run: npx playwright install --with-deps chromium
+
+      # Cache Playwright browsers
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(npm ls @playwright/test --json | jq -r '.dependencies["@playwright/test"].version')" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps only
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+
       - name: Run database migrations
         run: npm run db:migrate
         env:
           DATABASE_URL: postgresql://test:test@localhost:5432/habits_test
-      - run: npm run test:e2e
+
+      - name: Run E2E tests (shard ${{ matrix.shard }}/2)
+        run: npx playwright test --shard=${{ matrix.shard }}/2
         env:
           DATABASE_URL: postgresql://test:test@localhost:5432/habits_test
           NEXTAUTH_SECRET: test-secret-for-ci
@@ -61,8 +97,41 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           # Enable test endpoints in production build for E2E tests
           ALLOW_TEST_ENDPOINTS: true
-      - uses: actions/upload-artifact@v4
-        if: failure()
+
+      - name: Upload blob report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: blob-report-${{ matrix.shard }}
+          path: blob-report/
+          retention-days: 1
+
+  merge-reports:
+    if: always() && needs.e2e-tests.result != 'skipped'
+    needs: e2e-tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+
+      - name: Download blob reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: blob-report-*
+          path: all-blob-reports
+          merge-multiple: true
+
+      - name: Merge reports
+        run: npx playwright merge-reports --reporter html ./all-blob-reports
+
+      - name: Upload merged HTML report
+        if: failure() || needs.e2e-tests.result == 'failure'
+        uses: actions/upload-artifact@v4
         with:
           name: playwright-report
           path: playwright-report/
+          retention-days: 30

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,8 +5,8 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
-  reporter: [['html'], ['list']],
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI ? [['blob'], ['list']] : [['html'], ['list']],
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
     trace: 'on-first-retry',


### PR DESCRIPTION
## Summary

Optimizes the GitHub Actions CI workflow to reduce test execution time from ~6 minutes to ~2-3 minutes through:

- **Parallel job execution**: Unit tests and E2E tests now run concurrently instead of sequentially
- **Next.js build caching**: Caches `.next/cache` keyed by package-lock.json and src files
- **Playwright browser caching**: Caches browsers by Playwright version, only installing system deps on cache hit
- **E2E test sharding**: Splits E2E tests across 2 shards with `fail-fast: false`
- **Increased workers**: E2E tests now use 2 workers in CI (up from 1)
- **Report merging**: New `merge-reports` job combines blob reports into a single HTML report

## Changes

| File | Changes |
|------|---------|
| `playwright.config.ts` | Workers: 1→2, Reporter: blob for CI sharding |
| `.github/workflows/test.yml` | Complete rewrite with caching and parallelization |

## Expected Improvement

| Metric | Before | After |
|--------|--------|-------|
| Total CI time | ~6 min | ~2-3 min |
| E2E execution | ~4 min | ~2 min |
| Playwright install | ~40s | ~5s (cached) |

## Test plan

- [x] `npm run lint` passes (no errors)
- [x] `npm run build` succeeds
- [x] `npm run test:unit` passes (1113 tests)
- [ ] CI workflow runs successfully with new configuration
- [ ] Both E2E shards complete and merge-reports job produces HTML report
- [ ] Cache hits visible in subsequent CI runs

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)