### PR TITLE
feat: implement regional ingredient localization

### DIFF
--- a/scripts/migrations/019_user_region.sql
+++ b/scripts/migrations/019_user_region.sql
@@ -1,0 +1,12 @@
+-- Migration: 019_user_region
+-- Description: Add user region preference for regional ingredient localization
+-- The timezone is used as a region indicator, NOT for time-related purposes
+
+-- Add column for user's ingredient region preference
+-- NULL means auto-detect from the general timezone column
+-- When set, this overrides the general timezone for recipe regionalization
+ALTER TABLE users ADD COLUMN IF NOT EXISTS user_region_timezone VARCHAR(50) DEFAULT NULL;
+
+-- Note: The timezone stored here is used ONLY to determine the user's geographic region
+-- for ingredient name localization (e.g., Austrian "Schlagobers" vs German "Sahne").
+-- It is NOT used for time-related calculations.

--- a/src/app/api/recipes/extract-from-image/__tests__/route.test.ts
+++ b/src/app/api/recipes/extract-from-image/__tests__/route.test.ts
@@ -225,12 +225,15 @@ describe('POST /api/recipes/extract-from-image', () => {
       expect(data.slug).toBe('test-recipe');
     });
 
-    it('calls extractRecipeFromImage with base64 data', async () => {
+    it('calls extractRecipeFromImage with base64 data and user preferences', async () => {
       const request = createMockRequest({ imageBase64: 'somebase64data' });
 
       await POST(request);
 
-      expect(extractRecipeFromImage).toHaveBeenCalledWith('somebase64data');
+      expect(extractRecipeFromImage).toHaveBeenCalledWith('somebase64data', {
+        targetLocale: 'en-US',
+        targetRegion: expect.any(String),
+      });
     });
 
     it('generates slug from extracted title', async () => {

--- a/src/app/api/user/preferences/__tests__/route.test.ts
+++ b/src/app/api/user/preferences/__tests__/route.test.ts
@@ -288,7 +288,7 @@ describe('/api/user/preferences', () => {
         })
         mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 } as never)
         mockQuery.mockResolvedValueOnce({
-          rows: [{ timezone: 'Asia/Tokyo', locale: 'ja-JP', unit_system: 'imperial', default_recipe_locale: null, show_measurement_conversions: false }],
+          rows: [{ timezone: 'Asia/Tokyo', locale: 'ja-JP', unit_system: 'imperial', default_recipe_locale: null, show_measurement_conversions: false, user_region_timezone: null }],
           rowCount: 1
         } as never)
         mockUnstableUpdate.mockResolvedValueOnce(undefined)
@@ -308,7 +308,8 @@ describe('/api/user/preferences', () => {
             locale: 'ja-JP',
             unitSystem: 'imperial',
             defaultRecipeLocale: null,
-            showMeasurementConversions: false
+            showMeasurementConversions: false,
+            userRegionTimezone: null
           }
         })
       })
@@ -321,7 +322,7 @@ describe('/api/user/preferences', () => {
         mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 } as never)
         // DB returns null values
         mockQuery.mockResolvedValueOnce({
-          rows: [{ timezone: null, locale: null, unit_system: null, default_recipe_locale: null, show_measurement_conversions: null }],
+          rows: [{ timezone: null, locale: null, unit_system: null, default_recipe_locale: null, show_measurement_conversions: null, user_region_timezone: null }],
           rowCount: 1
         } as never)
         mockUnstableUpdate.mockResolvedValueOnce(undefined)
@@ -336,7 +337,8 @@ describe('/api/user/preferences', () => {
             locale: 'en-US',
             unitSystem: 'metric',
             defaultRecipeLocale: null,
-            showMeasurementConversions: false
+            showMeasurementConversions: false,
+            userRegionTimezone: null
           }
         })
       })

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -24,6 +24,7 @@ export default async function SettingsPage() {
             unitSystem: session.user.unitSystem,
             defaultRecipeLocale: session.user.defaultRecipeLocale,
             showMeasurementConversions: session.user.showMeasurementConversions,
+            userRegionTimezone: session.user.userRegionTimezone,
           }}
           userName={session.user.name ?? undefined}
           userEmail={session.user.email ?? undefined}

--- a/src/components/UserSettingsForm.tsx
+++ b/src/components/UserSettingsForm.tsx
@@ -9,6 +9,8 @@ import {
   SUPPORTED_LOCALES,
   UNIT_SYSTEMS,
   RECIPE_LOCALE_OPTIONS,
+  REGION_OPTIONS,
+  getRegionFromTimezone,
 } from '@/lib/user-preferences';
 
 interface UserSettingsFormProps {
@@ -28,6 +30,7 @@ export function UserSettingsForm({
   const [unitSystem, setUnitSystem] = useState<UnitSystem>(initialPreferences.unitSystem);
   const [defaultRecipeLocale, setDefaultRecipeLocale] = useState(initialPreferences.defaultRecipeLocale ?? '');
   const [showMeasurementConversions, setShowMeasurementConversions] = useState(initialPreferences.showMeasurementConversions);
+  const [userRegionTimezone, setUserRegionTimezone] = useState(initialPreferences.userRegionTimezone ?? '');
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState(false);
@@ -48,6 +51,7 @@ export function UserSettingsForm({
           unitSystem,
           defaultRecipeLocale,
           showMeasurementConversions,
+          userRegionTimezone,
         }),
       });
 
@@ -209,6 +213,48 @@ export function UserSettingsForm({
             </select>
             <p className="text-slate-500 text-xs mt-1">
               Language used when the AI creates new recipes for you
+            </p>
+          </div>
+
+          {/* Ingredient Region */}
+          <div className="mb-4">
+            <label htmlFor="userRegionTimezone" className="block text-sm mb-2 text-slate-300">
+              Ingredient Region
+            </label>
+            <div className="flex gap-2">
+              <select
+                id="userRegionTimezone"
+                value={userRegionTimezone}
+                onChange={(e) => setUserRegionTimezone(e.target.value)}
+                disabled={saving}
+                className="flex-1 p-3 rounded bg-slate-800 border border-slate-700 focus:border-emerald-500 outline-none disabled:opacity-50 text-slate-100"
+              >
+                {REGION_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+                {/* Show custom timezone if not in predefined list */}
+                {userRegionTimezone && !REGION_OPTIONS.some(r => r.value === userRegionTimezone) && (
+                  <option value={userRegionTimezone}>
+                    {getRegionFromTimezone(userRegionTimezone)}
+                  </option>
+                )}
+              </select>
+              <button
+                type="button"
+                onClick={() => {
+                  const detected = Intl.DateTimeFormat().resolvedOptions().timeZone;
+                  setUserRegionTimezone(detected);
+                }}
+                disabled={saving}
+                className="px-3 py-2 rounded bg-slate-700 hover:bg-slate-600 text-slate-300 text-sm disabled:opacity-50"
+              >
+                Detect
+              </button>
+            </div>
+            <p className="text-slate-500 text-xs mt-1">
+              Adapts ingredient names to your region (e.g., Austrian &quot;Schlagobers&quot; vs. German &quot;Sahne&quot;)
             </p>
           </div>
 

--- a/src/lib/__tests__/recipe-translation.test.ts
+++ b/src/lib/__tests__/recipe-translation.test.ts
@@ -148,6 +148,7 @@ describe('recipe-translation', () => {
         '123',
         1,
         'de-DE' as TranslationLocale,
+        null, // targetRegion
         true,
         false
       )
@@ -170,6 +171,7 @@ describe('recipe-translation', () => {
           '123',
           999,
           'de-DE' as TranslationLocale,
+          null, // targetRegion
           true,
           false
         )
@@ -202,6 +204,7 @@ describe('recipe-translation', () => {
           '123',
           1,
           'xx-XX' as TranslationLocale,
+          null, // targetRegion
           true,
           false
         )
@@ -234,6 +237,7 @@ describe('recipe-translation', () => {
           '123',
           1,
           'de-DE' as TranslationLocale,
+          null, // targetRegion
           true,
           false
         )
@@ -294,6 +298,7 @@ describe('recipe-translation', () => {
         '123',
         1,
         'de-DE' as TranslationLocale,
+        null, // targetRegion
         true,
         true
       )
@@ -351,6 +356,7 @@ describe('recipe-translation', () => {
         '123',
         1,
         'de-DE' as TranslationLocale,
+        null, // targetRegion
         true,
         false
       )
@@ -402,6 +408,7 @@ describe('recipe-translation', () => {
           '123',
           1,
           'de-DE' as TranslationLocale,
+          null, // targetRegion
           true,
           false
         )
@@ -451,6 +458,7 @@ describe('recipe-translation', () => {
           '123',
           1,
           'de-DE' as TranslationLocale,
+          null, // targetRegion
           true,
           false
         )
@@ -501,6 +509,7 @@ describe('recipe-translation', () => {
         '123',
         1,
         'de-DE' as TranslationLocale,
+        null, // targetRegion
         true,
         false
       )
@@ -557,6 +566,7 @@ describe('recipe-translation', () => {
         '123',
         1,
         'de-DE' as TranslationLocale, // Metric
+        null, // targetRegion
         true, // adaptMeasurements = true
         false
       )
@@ -611,6 +621,7 @@ describe('recipe-translation', () => {
         '123',
         1,
         'de-DE' as TranslationLocale,
+        null, // targetRegion
         false, // adaptMeasurements = false
         false
       )
@@ -659,6 +670,7 @@ describe('recipe-translation', () => {
         '123',
         1,
         'de-DE' as TranslationLocale,
+        null, // targetRegion
         true,
         false
       )

--- a/src/lib/__tests__/regional-ingredients.test.ts
+++ b/src/lib/__tests__/regional-ingredients.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest";
+import {
+  REGIONAL_INGREDIENT_EXAMPLES,
+  getRegionalIngredientContext,
+} from "../regional-ingredients";
+
+describe("Regional Ingredients", () => {
+  describe("REGIONAL_INGREDIENT_EXAMPLES", () => {
+    it("contains examples for Austria", () => {
+      const austria = REGIONAL_INGREDIENT_EXAMPLES["Austria"];
+      expect(austria).toBeDefined();
+      expect(austria.cream).toBe("Schlagobers");
+      expect(austria.tomato).toBe("Paradeiser");
+      expect(austria.potato).toBe("Erdäpfel");
+      expect(austria.cottage_cheese).toBe("Topfen");
+    });
+
+    it("contains examples for Germany", () => {
+      const germany = REGIONAL_INGREDIENT_EXAMPLES["Germany"];
+      expect(germany).toBeDefined();
+      expect(germany.cream).toBe("Sahne");
+      expect(germany.tomato).toBe("Tomate");
+      expect(germany.potato).toBe("Kartoffel");
+      expect(germany.cottage_cheese).toBe("Quark");
+    });
+
+    it("contains examples for Switzerland", () => {
+      const switzerland = REGIONAL_INGREDIENT_EXAMPLES["Switzerland"];
+      expect(switzerland).toBeDefined();
+      expect(switzerland.cream).toBe("Rahm");
+      expect(switzerland.cottage_cheese).toBe("Quark");
+    });
+
+    it("contains examples for United Kingdom", () => {
+      const uk = REGIONAL_INGREDIENT_EXAMPLES["United Kingdom"];
+      expect(uk).toBeDefined();
+      expect(uk.cilantro).toBe("coriander");
+      expect(uk.eggplant).toBe("aubergine");
+      expect(uk.zucchini).toBe("courgette");
+      expect(uk.arugula).toBe("rocket");
+    });
+
+    it("contains examples for United States", () => {
+      const us = REGIONAL_INGREDIENT_EXAMPLES["United States"];
+      expect(us).toBeDefined();
+      expect(us.coriander).toBe("cilantro");
+      expect(us.aubergine).toBe("eggplant");
+      expect(us.courgette).toBe("zucchini");
+    });
+
+    it("distinguishes between Austrian and German terms", () => {
+      const austria = REGIONAL_INGREDIENT_EXAMPLES["Austria"];
+      const germany = REGIONAL_INGREDIENT_EXAMPLES["Germany"];
+
+      // These should be different
+      expect(austria.cream).not.toBe(germany.cream);
+      expect(austria.tomato).not.toBe(germany.tomato);
+      expect(austria.potato).not.toBe(germany.potato);
+      expect(austria.cottage_cheese).not.toBe(germany.cottage_cheese);
+      expect(austria.apricot).not.toBe(germany.apricot);
+    });
+
+    it("has non-empty values for all entries", () => {
+      Object.values(REGIONAL_INGREDIENT_EXAMPLES).forEach((ingredients) => {
+        Object.values(ingredients).forEach((value) => {
+          expect(value.length).toBeGreaterThan(0);
+          // Allow same value if it's a common term (like "Paprika" in German regions)
+          // Just ensure it's a valid string
+          expect(typeof value).toBe("string");
+        });
+      });
+    });
+  });
+
+  describe("getRegionalIngredientContext", () => {
+    it("returns Austria-specific context for Austria", () => {
+      const context = getRegionalIngredientContext("Austria");
+      expect(context).toContain("Austria-specific");
+      expect(context).toContain("Schlagobers");
+    });
+
+    it("returns Germany-specific context for Germany", () => {
+      const context = getRegionalIngredientContext("Germany");
+      expect(context).toContain("Germany-specific");
+      expect(context).toContain("Sahne");
+    });
+
+    it("returns Switzerland-specific context for Switzerland", () => {
+      const context = getRegionalIngredientContext("Switzerland");
+      expect(context).toContain("Switzerland-specific");
+      expect(context).toContain("Rahm");
+    });
+
+    it("returns UK-specific context for United Kingdom", () => {
+      const context = getRegionalIngredientContext("United Kingdom");
+      expect(context).toContain("United Kingdom-specific");
+      expect(context).toContain("coriander");
+    });
+
+    it("returns US-specific context for United States", () => {
+      const context = getRegionalIngredientContext("United States");
+      expect(context).toContain("United States-specific");
+      expect(context).toContain("cilantro");
+    });
+
+    it("returns generic context for unknown regions", () => {
+      const context = getRegionalIngredientContext("Unknown Region");
+      expect(context).toContain("appropriate for");
+      expect(context).toContain("Unknown Region");
+    });
+
+    it("includes examples in the format 'key → value'", () => {
+      const context = getRegionalIngredientContext("Austria");
+      expect(context).toMatch(/"\w+" → "\w+"/);
+      expect(context).toContain("Examples:");
+    });
+
+    it("limits the number of examples to keep prompt concise", () => {
+      const context = getRegionalIngredientContext("Austria");
+      // Count the number of arrow patterns
+      const arrowCount = (context.match(/→/g) || []).length;
+      // Should be limited (we set it to 6 in the implementation)
+      expect(arrowCount).toBeLessThanOrEqual(6);
+      expect(arrowCount).toBeGreaterThan(0);
+    });
+
+    it("converts underscores to spaces in example keys", () => {
+      const context = getRegionalIngredientContext("Austria");
+      // "cottage_cheese" should appear as "cottage cheese"
+      expect(context).not.toContain("_");
+    });
+
+    it("handles US regional variants", () => {
+      const eastCoast = getRegionalIngredientContext("United States (East Coast)");
+      const westCoast = getRegionalIngredientContext("United States (West Coast)");
+      const midwest = getRegionalIngredientContext("United States (Midwest)");
+
+      // All should return context with US ingredients
+      expect(eastCoast).toContain("cilantro");
+      expect(westCoast).toContain("cilantro");
+      expect(midwest).toContain("cilantro");
+    });
+  });
+});

--- a/src/lib/regional-ingredients.ts
+++ b/src/lib/regional-ingredients.ts
@@ -1,0 +1,199 @@
+/**
+ * Regional ingredient name references for AI context
+ * Used to help AI translate ingredients to region-specific terminology
+ *
+ * NOTE: This is reference data included in AI prompts, not a lookup table.
+ * The AI uses these examples to understand regional variations.
+ */
+
+/**
+ * Regional ingredient examples organized by region name
+ * Keys are human-readable region names (matching TIMEZONE_TO_REGION output)
+ * Values are maps of generic ingredient concepts to local names
+ */
+export const REGIONAL_INGREDIENT_EXAMPLES: Record<string, Record<string, string>> = {
+  // Austrian German (de-AT)
+  'Austria': {
+    cream: 'Schlagobers',
+    whipped_cream: 'Schlagobers',
+    tomato: 'Paradeiser',
+    potato: 'Erdäpfel',
+    green_beans: 'Fisolen',
+    bell_pepper: 'Paprika',
+    apricot: 'Marille',
+    cottage_cheese: 'Topfen',
+    horseradish: 'Kren',
+    danish_pastry: 'Golatsche',
+    cauliflower: 'Karfiol',
+    corn: 'Kukuruz',
+    pancake: 'Palatschinken',
+    eggplant: 'Melanzani',
+  },
+  // German German (de-DE)
+  'Germany': {
+    cream: 'Sahne',
+    whipped_cream: 'Schlagsahne',
+    tomato: 'Tomate',
+    potato: 'Kartoffel',
+    green_beans: 'grüne Bohnen',
+    bell_pepper: 'Paprika',
+    apricot: 'Aprikose',
+    cottage_cheese: 'Quark',
+    horseradish: 'Meerrettich',
+    danish_pastry: 'Plundergebäck',
+    cauliflower: 'Blumenkohl',
+    corn: 'Mais',
+    pancake: 'Pfannkuchen',
+    eggplant: 'Aubergine',
+  },
+  // Swiss German (de-CH)
+  'Switzerland': {
+    cream: 'Rahm',
+    whipped_cream: 'Schlagrahm',
+    tomato: 'Tomate',
+    potato: 'Kartoffel',
+    cottage_cheese: 'Quark',
+    green_beans: 'grüne Bohnen',
+    bell_pepper: 'Peperoni',
+    apricot: 'Aprikose',
+    corn: 'Mais',
+    pancake: 'Pfannkuchen',
+    eggplant: 'Aubergine',
+  },
+  // UK English
+  'United Kingdom': {
+    cilantro: 'coriander',
+    eggplant: 'aubergine',
+    zucchini: 'courgette',
+    arugula: 'rocket',
+    bell_pepper: 'pepper',
+    shrimp: 'prawns',
+    cookie: 'biscuit',
+    chips: 'crisps',
+    french_fries: 'chips',
+    all_purpose_flour: 'plain flour',
+    powdered_sugar: 'icing sugar',
+    heavy_cream: 'double cream',
+    beet: 'beetroot',
+    ground_meat: 'mince',
+  },
+  // US English
+  'United States': {
+    coriander: 'cilantro',
+    aubergine: 'eggplant',
+    courgette: 'zucchini',
+    rocket: 'arugula',
+    prawns: 'shrimp',
+    biscuit: 'cookie',
+    crisps: 'chips',
+    plain_flour: 'all-purpose flour',
+    icing_sugar: 'powdered sugar',
+    double_cream: 'heavy cream',
+    beetroot: 'beet',
+    mince: 'ground meat',
+  },
+  'United States (East Coast)': {
+    coriander: 'cilantro',
+    aubergine: 'eggplant',
+    courgette: 'zucchini',
+    rocket: 'arugula',
+    prawns: 'shrimp',
+    plain_flour: 'all-purpose flour',
+    icing_sugar: 'powdered sugar',
+    double_cream: 'heavy cream',
+  },
+  'United States (West Coast)': {
+    coriander: 'cilantro',
+    aubergine: 'eggplant',
+    courgette: 'zucchini',
+    rocket: 'arugula',
+    prawns: 'shrimp',
+    plain_flour: 'all-purpose flour',
+    icing_sugar: 'powdered sugar',
+    double_cream: 'heavy cream',
+  },
+  'United States (Midwest)': {
+    coriander: 'cilantro',
+    aubergine: 'eggplant',
+    courgette: 'zucchini',
+    rocket: 'arugula',
+    prawns: 'shrimp',
+    plain_flour: 'all-purpose flour',
+    icing_sugar: 'powdered sugar',
+    double_cream: 'heavy cream',
+  },
+  // French (France)
+  'France': {
+    eggplant: 'aubergine',
+    zucchini: 'courgette',
+    bell_pepper: 'poivron',
+    shrimp: 'crevettes',
+    cream: 'crème',
+    whipped_cream: 'crème fouettée',
+  },
+  // Italian (Italy)
+  'Italy': {
+    eggplant: 'melanzana',
+    zucchini: 'zucchina',
+    bell_pepper: 'peperone',
+    shrimp: 'gamberi',
+    cream: 'panna',
+    tomato: 'pomodoro',
+  },
+  // Spanish (Spain)
+  'Spain': {
+    eggplant: 'berenjena',
+    zucchini: 'calabacín',
+    bell_pepper: 'pimiento',
+    shrimp: 'gambas',
+    cream: 'nata',
+    tomato: 'tomate',
+  },
+  // Dutch (Netherlands)
+  'Netherlands': {
+    eggplant: 'aubergine',
+    zucchini: 'courgette',
+    bell_pepper: 'paprika',
+    cream: 'slagroom',
+    tomato: 'tomaat',
+    potato: 'aardappel',
+  },
+  // Australian English
+  'Australia': {
+    bell_pepper: 'capsicum',
+    shrimp: 'prawns',
+    cilantro: 'coriander',
+    eggplant: 'eggplant',
+    zucchini: 'zucchini',
+    arugula: 'rocket',
+  },
+  // Japanese
+  'Japan': {
+    green_onion: 'negi',
+    daikon: 'daikon radish',
+    tofu: 'tofu',
+    soy_sauce: 'shoyu',
+  },
+};
+
+/**
+ * Generate regional ingredient context for AI prompts
+ * Returns examples specific to the user's region
+ *
+ * @param regionName - Human-readable region name (e.g., "Austria", "Germany")
+ * @returns A string with regional ingredient guidance for AI prompts
+ */
+export function getRegionalIngredientContext(regionName: string): string {
+  const examples = REGIONAL_INGREDIENT_EXAMPLES[regionName];
+
+  if (!examples) {
+    return `Adapt ingredient names to be appropriate for ${regionName}.`;
+  }
+
+  const exampleList = Object.entries(examples)
+    .slice(0, 6) // Limit to 6 examples to keep prompt concise
+    .map(([eng, local]) => `"${eng.replace(/_/g, ' ')}" → "${local}"`)
+    .join(', ');
+
+  return `Use ${regionName}-specific ingredient names. Examples: ${exampleList}`;
+}

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -14,6 +14,7 @@ declare module "next-auth" {
       onboardingCompleted?: boolean;
       defaultRecipeLocale: string | null;
       showMeasurementConversions: boolean;
+      userRegionTimezone: string | null;
     };
   }
 
@@ -28,6 +29,7 @@ declare module "next-auth" {
     unitSystem?: UnitSystem;
     defaultRecipeLocale?: string | null;
     showMeasurementConversions?: boolean;
+    userRegionTimezone?: string | null;
   }
 }
 
@@ -40,5 +42,6 @@ declare module "next-auth/jwt" {
     unitSystem?: UnitSystem;
     defaultRecipeLocale?: string | null;
     showMeasurementConversions?: boolean;
+    userRegionTimezone?: string | null;
   }
 }


### PR DESCRIPTION
## Summary

Implements #186 - Regional Ingredient Localization

- **User region preference**: Adds `user_region_timezone` field to store the user's region (using timezone as geographic indicator)
- **Settings UI**: New "Ingredient Region" dropdown in Recipe Preferences with auto-detect button
- **Recipe creation**: AI prompts now include regional context for ingredient naming
- **Recipe translation**: `translateRecipeTool` accepts optional `targetRegion` parameter
- **Image import**: Recipe extraction adapts ingredients to user's region

### Regional Examples
- Austria: "Schlagobers" instead of "Sahne" (cream), "Paradeiser" instead of "Tomate" (tomato)
- UK: "Coriander" instead of "Cilantro", "Aubergine" instead of "Eggplant"
- US: "All-purpose flour" instead of "Plain flour"

## Test plan

- [x] Unit tests pass (1179 tests)
- [x] Build succeeds
- [x] Manual testing: Settings page shows Ingredient Region selector
- [x] Manual testing: Region selection saves and persists after refresh
- [x] Manual testing: Detect button auto-detects browser timezone

🤖 Generated with [Claude Code](https://claude.com/claude-code)