### PR TITLE
feat: add PDF import support for recipe extraction

### DIFF
--- a/e2e/recipes.spec.ts
+++ b/e2e/recipes.spec.ts
@@ -294,7 +294,7 @@ test.describe('Recipe Feature', () => {
       await authenticatedPage.goto('/recipes');
 
       // Camera button should be visible
-      const cameraButton = authenticatedPage.getByRole('button', { name: /import recipe from photo/i });
+      const cameraButton = authenticatedPage.getByRole('button', { name: /import recipe from photo or pdf/i });
       await expect(cameraButton).toBeVisible();
     });
 
@@ -302,7 +302,7 @@ test.describe('Recipe Feature', () => {
       await authenticatedPage.goto('/recipes');
 
       // Click camera button
-      const cameraButton = authenticatedPage.getByRole('button', { name: /import recipe from photo/i });
+      const cameraButton = authenticatedPage.getByRole('button', { name: /import recipe from photo or pdf/i });
       await cameraButton.click();
 
       // Modal should open with "Import Recipe" heading
@@ -313,7 +313,7 @@ test.describe('Recipe Feature', () => {
       await authenticatedPage.goto('/recipes');
 
       // Open modal
-      const cameraButton = authenticatedPage.getByRole('button', { name: /import recipe from photo/i });
+      const cameraButton = authenticatedPage.getByRole('button', { name: /import recipe from photo or pdf/i });
       await cameraButton.click();
 
       // Cancel button should be visible
@@ -324,7 +324,7 @@ test.describe('Recipe Feature', () => {
       await authenticatedPage.goto('/recipes');
 
       // Open modal
-      const cameraButton = authenticatedPage.getByRole('button', { name: /import recipe from photo/i });
+      const cameraButton = authenticatedPage.getByRole('button', { name: /import recipe from photo or pdf/i });
       await cameraButton.click();
 
       // Click cancel
@@ -339,7 +339,7 @@ test.describe('Recipe Feature', () => {
       await authenticatedPage.goto('/recipes');
 
       // Open modal
-      const cameraButton = authenticatedPage.getByRole('button', { name: /import recipe from photo/i });
+      const cameraButton = authenticatedPage.getByRole('button', { name: /import recipe from photo or pdf/i });
       await cameraButton.click();
 
       // Click close button (×)
@@ -355,12 +355,12 @@ test.describe('Recipe Feature', () => {
       await authenticatedPage.setViewportSize({ width: 1024, height: 768 });
       await authenticatedPage.goto('/recipes');
 
-      // Open modal
-      const cameraButton = authenticatedPage.getByRole('button', { name: /import recipe from photo/i });
-      await cameraButton.click();
+      // Open modal (now supports both photos and PDFs)
+      const importButton = authenticatedPage.getByRole('button', { name: /import recipe from photo or pdf/i });
+      await importButton.click();
 
-      // Should show drop zone text
-      await expect(authenticatedPage.getByText(/drop image here/i)).toBeVisible();
+      // Should show drop zone text (updated for PDF support)
+      await expect(authenticatedPage.getByText(/drop file here/i)).toBeVisible();
     });
 
     test('mobile view shows camera and library buttons', async ({ authenticatedPage }) => {
@@ -368,13 +368,13 @@ test.describe('Recipe Feature', () => {
       await authenticatedPage.setViewportSize({ width: 375, height: 667 });
       await authenticatedPage.goto('/recipes');
 
-      // Open modal
-      const cameraButton = authenticatedPage.getByRole('button', { name: /import recipe from photo/i });
-      await cameraButton.click();
+      // Open modal (now supports both photos and PDFs)
+      const importButton = authenticatedPage.getByRole('button', { name: /import recipe from photo or pdf/i });
+      await importButton.click();
 
-      // Should show camera and library buttons
+      // Should show camera and library buttons (updated for PDF support)
       await expect(authenticatedPage.getByText('Take Photo')).toBeVisible();
-      await expect(authenticatedPage.getByText('Choose from Library')).toBeVisible();
+      await expect(authenticatedPage.getByText('Choose File')).toBeVisible();
     });
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "next": "^16.1.1",
         "next-auth": "^5.0.0-beta.30",
         "openai": "^6.15.0",
+        "pdf-parse": "^2.4.5",
+        "pdfjs-dist": "^5.4.530",
         "pg": "^8.16.3",
         "react": "19.2.0",
         "react-dom": "19.2.0"
@@ -27,6 +29,7 @@
         "@types/bcryptjs": "^2.4.6",
         "@types/canvas-confetti": "^1.9.0",
         "@types/node": "^20",
+        "@types/pdf-parse": "^1.1.5",
         "@types/pg": "^8.15.6",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -1759,6 +1762,210 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.80.tgz",
+      "integrity": "sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww==",
+      "license": "MIT",
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.80",
+        "@napi-rs/canvas-darwin-arm64": "0.1.80",
+        "@napi-rs/canvas-darwin-x64": "0.1.80",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.80",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.80",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.80",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.80"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.80.tgz",
+      "integrity": "sha512-sk7xhN/MoXeuExlggf91pNziBxLPVUqF2CAVnB57KLG/pz7+U5TKG8eXdc3pm0d7Od0WreB6ZKLj37sX9muGOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.80.tgz",
+      "integrity": "sha512-O64APRTXRUiAz0P8gErkfEr3lipLJgM6pjATwavZ22ebhjYl/SUbpgM0xcWPQBNMP1n29afAC/Us5PX1vg+JNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.80.tgz",
+      "integrity": "sha512-FqqSU7qFce0Cp3pwnTjVkKjjOtxMqRe6lmINxpIZYaZNnVI0H5FtsaraZJ36SiTHNjZlUB69/HhxNDT1Aaa9vA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.80.tgz",
+      "integrity": "sha512-eyWz0ddBDQc7/JbAtY4OtZ5SpK8tR4JsCYEZjCE3dI8pqoWUC8oMwYSBGCYfsx2w47cQgQCgMVRVTFiiO38hHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.80.tgz",
+      "integrity": "sha512-qwA63t8A86bnxhuA/GwOkK3jvb+XTQaTiVML0vAWoHyoZYTjNs7BzoOONDgTnNtr8/yHrq64XXzUoLqDzU+Uuw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.80.tgz",
+      "integrity": "sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.80.tgz",
+      "integrity": "sha512-XTzR125w5ZMs0lJcxRlS1K3P5RaZ9RmUsPtd1uGt+EfDyYMu4c6SEROYsxyatbbu/2+lPe7MPHOO/0a0x7L/gw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.80.tgz",
+      "integrity": "sha512-BeXAmhKg1kX3UCrJsYbdQd3hIMDH/K6HnP/pG2LuITaXhXBiNdh//TVVVVCBbJzVQaV5gK/4ZOCMrQW9mvuTqA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.80.tgz",
+      "integrity": "sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.88",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.88.tgz",
+      "integrity": "sha512-qcIFfEgHrchyYqRrxsCeTQgpJZ/GqHiqPcU/Fvw/ARVlQeDX1VyFH+X+0gCR2tca6UJrq96vnW+5o7buCq+erA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.80.tgz",
+      "integrity": "sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -2863,6 +3070,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pdf-parse": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/pdf-parse/-/pdf-parse-1.1.5.tgz",
+      "integrity": "sha512-kBfrSXsloMnUJOKi25s3+hRmkycHfLK6A09eRGqF/N8BkQoPUmaCr+q8Cli5FnfohEz/rsv82zAiPz/LXtOGhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/pg": {
@@ -7405,6 +7622,280 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pdf-parse": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-2.4.5.tgz",
+      "integrity": "sha512-mHU89HGh7v+4u2ubfnevJ03lmPgQ5WU4CxAVmTSh/sxVTEDYd1er/dKS/A6vg77NX47KTEoihq8jZBLr8Cxuwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@napi-rs/canvas": "0.1.80",
+        "pdfjs-dist": "5.4.296"
+      },
+      "bin": {
+        "pdf-parse": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.16.0 <21 || >=22.3.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/mehmet-kozan"
+      }
+    },
+    "node_modules/pdf-parse/node_modules/pdfjs-dist": {
+      "version": "5.4.296",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz",
+      "integrity": "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.80"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.4.530",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.530.tgz",
+      "integrity": "sha512-r1hWsSIGGmyYUAHR26zSXkxYWLXLMd6AwqcaFYG9YUZ0GBf5GvcjJSeo512tabM4GYFhxhl5pMCmPr7Q72Rq2Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.84"
+      }
+    },
+    "node_modules/pdfjs-dist/node_modules/@napi-rs/canvas": {
+      "version": "0.1.88",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.88.tgz",
+      "integrity": "sha512-/p08f93LEbsL5mDZFQ3DBxcPv/I4QG9EDYRRq1WNlCOXVfAHBTHMSVMwxlqG/AtnSfUr9+vgfN7MKiyDo0+Weg==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.88",
+        "@napi-rs/canvas-darwin-arm64": "0.1.88",
+        "@napi-rs/canvas-darwin-x64": "0.1.88",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.88",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.88",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.88",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.88",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.88",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.88",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.88",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.88"
+      }
+    },
+    "node_modules/pdfjs-dist/node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.88",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.88.tgz",
+      "integrity": "sha512-KEaClPnZuVxJ8smUWjV1wWFkByBO/D+vy4lN+Dm5DFH514oqwukxKGeck9xcKJhaWJGjfruGmYGiwRe//+/zQQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/pdfjs-dist/node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.88",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.88.tgz",
+      "integrity": "sha512-Xgywz0dDxOKSgx3eZnK85WgGMmGrQEW7ZLA/E7raZdlEE+xXCozobgqz2ZvYigpB6DJFYkqnwHjqCOTSDGlFdg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/pdfjs-dist/node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.88",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.88.tgz",
+      "integrity": "sha512-Yz4wSCIQOUgNucgk+8NFtQxQxZV5NO8VKRl9ePKE6XoNyNVC8JDqtvhh3b3TPqKK8W5p2EQpAr1rjjm0mfBxdg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/pdfjs-dist/node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.88",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.88.tgz",
+      "integrity": "sha512-9gQM2SlTo76hYhxHi2XxWTAqpTOb+JtxMPEIr+H5nAhHhyEtNmTSDRtz93SP7mGd2G3Ojf2oF5tP9OdgtgXyKg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/pdfjs-dist/node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.88",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.88.tgz",
+      "integrity": "sha512-7qgaOBMXuVRk9Fzztzr3BchQKXDxGbY+nwsovD3I/Sx81e+sX0ReEDYHTItNb0Je4NHbAl7D0MKyd4SvUc04sg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/pdfjs-dist/node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.88",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.88.tgz",
+      "integrity": "sha512-kYyNrUsHLkoGHBc77u4Unh067GrfiCUMbGHC2+OTxbeWfZkPt2o32UOQkhnSswKd9Fko/wSqqGkY956bIUzruA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/pdfjs-dist/node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.88",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.88.tgz",
+      "integrity": "sha512-HVuH7QgzB0yavYdNZDRyAsn/ejoXB0hn8twwFnOqUbCCdkV+REna7RXjSR7+PdfW0qMQ2YYWsLvVBT5iL/mGpw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/pdfjs-dist/node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.88",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.88.tgz",
+      "integrity": "sha512-hvcvKIcPEQrvvJtJnwD35B3qk6umFJ8dFIr8bSymfrSMem0EQsfn1ztys8ETIFndTwdNWJKWluvxztA41ivsEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/pdfjs-dist/node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.88",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.88.tgz",
+      "integrity": "sha512-eSMpGYY2xnZSQ6UxYJ6plDboxq4KeJ4zT5HaVkUnbObNN6DlbJe0Mclh3wifAmquXfrlgTZt6zhHsUgz++AK6g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/pdfjs-dist/node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.88",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.88.tgz",
+      "integrity": "sha512-ROVqbfS4QyZxYkqmaIBBpbz/BQvAR+05FXM5PAtTYVc0uyY8Y4BHJSMdGAaMf6TdIVRsQsiq+FG/dH9XhvWCFQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
     "node_modules/pg": {
       "version": "8.16.3",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
@@ -10342,6 +10833,89 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "@napi-rs/canvas": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.80.tgz",
+      "integrity": "sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww==",
+      "requires": {
+        "@napi-rs/canvas-android-arm64": "0.1.80",
+        "@napi-rs/canvas-darwin-arm64": "0.1.80",
+        "@napi-rs/canvas-darwin-x64": "0.1.80",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.80",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.80",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.80",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.80"
+      }
+    },
+    "@napi-rs/canvas-android-arm64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.80.tgz",
+      "integrity": "sha512-sk7xhN/MoXeuExlggf91pNziBxLPVUqF2CAVnB57KLG/pz7+U5TKG8eXdc3pm0d7Od0WreB6ZKLj37sX9muGOQ==",
+      "optional": true
+    },
+    "@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.80.tgz",
+      "integrity": "sha512-O64APRTXRUiAz0P8gErkfEr3lipLJgM6pjATwavZ22ebhjYl/SUbpgM0xcWPQBNMP1n29afAC/Us5PX1vg+JNQ==",
+      "optional": true
+    },
+    "@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.80.tgz",
+      "integrity": "sha512-FqqSU7qFce0Cp3pwnTjVkKjjOtxMqRe6lmINxpIZYaZNnVI0H5FtsaraZJ36SiTHNjZlUB69/HhxNDT1Aaa9vA==",
+      "optional": true
+    },
+    "@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.80.tgz",
+      "integrity": "sha512-eyWz0ddBDQc7/JbAtY4OtZ5SpK8tR4JsCYEZjCE3dI8pqoWUC8oMwYSBGCYfsx2w47cQgQCgMVRVTFiiO38hHQ==",
+      "optional": true
+    },
+    "@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.80.tgz",
+      "integrity": "sha512-qwA63t8A86bnxhuA/GwOkK3jvb+XTQaTiVML0vAWoHyoZYTjNs7BzoOONDgTnNtr8/yHrq64XXzUoLqDzU+Uuw==",
+      "optional": true
+    },
+    "@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.80.tgz",
+      "integrity": "sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg==",
+      "optional": true
+    },
+    "@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.80.tgz",
+      "integrity": "sha512-XTzR125w5ZMs0lJcxRlS1K3P5RaZ9RmUsPtd1uGt+EfDyYMu4c6SEROYsxyatbbu/2+lPe7MPHOO/0a0x7L/gw==",
+      "optional": true
+    },
+    "@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.80.tgz",
+      "integrity": "sha512-BeXAmhKg1kX3UCrJsYbdQd3hIMDH/K6HnP/pG2LuITaXhXBiNdh//TVVVVCBbJzVQaV5gK/4ZOCMrQW9mvuTqA==",
+      "optional": true
+    },
+    "@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.80.tgz",
+      "integrity": "sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg==",
+      "optional": true
+    },
+    "@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.88",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.88.tgz",
+      "integrity": "sha512-qcIFfEgHrchyYqRrxsCeTQgpJZ/GqHiqPcU/Fvw/ARVlQeDX1VyFH+X+0gCR2tca6UJrq96vnW+5o7buCq+erA==",
+      "optional": true
+    },
+    "@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.80.tgz",
+      "integrity": "sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg==",
+      "optional": true
+    },
     "@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -10978,6 +11552,15 @@
       "dev": true,
       "requires": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "@types/pdf-parse": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/pdf-parse/-/pdf-parse-1.1.5.tgz",
+      "integrity": "sha512-kBfrSXsloMnUJOKi25s3+hRmkycHfLK6A09eRGqF/N8BkQoPUmaCr+q8Cli5FnfohEz/rsv82zAiPz/LXtOGhA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/pg": {
@@ -13818,6 +14401,114 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true
+    },
+    "pdf-parse": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-2.4.5.tgz",
+      "integrity": "sha512-mHU89HGh7v+4u2ubfnevJ03lmPgQ5WU4CxAVmTSh/sxVTEDYd1er/dKS/A6vg77NX47KTEoihq8jZBLr8Cxuwg==",
+      "requires": {
+        "@napi-rs/canvas": "0.1.80",
+        "pdfjs-dist": "5.4.296"
+      },
+      "dependencies": {
+        "pdfjs-dist": {
+          "version": "5.4.296",
+          "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz",
+          "integrity": "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==",
+          "requires": {
+            "@napi-rs/canvas": "^0.1.80"
+          }
+        }
+      }
+    },
+    "pdfjs-dist": {
+      "version": "5.4.530",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.530.tgz",
+      "integrity": "sha512-r1hWsSIGGmyYUAHR26zSXkxYWLXLMd6AwqcaFYG9YUZ0GBf5GvcjJSeo512tabM4GYFhxhl5pMCmPr7Q72Rq2Q==",
+      "requires": {
+        "@napi-rs/canvas": "^0.1.84"
+      },
+      "dependencies": {
+        "@napi-rs/canvas": {
+          "version": "0.1.88",
+          "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.88.tgz",
+          "integrity": "sha512-/p08f93LEbsL5mDZFQ3DBxcPv/I4QG9EDYRRq1WNlCOXVfAHBTHMSVMwxlqG/AtnSfUr9+vgfN7MKiyDo0+Weg==",
+          "optional": true,
+          "requires": {
+            "@napi-rs/canvas-android-arm64": "0.1.88",
+            "@napi-rs/canvas-darwin-arm64": "0.1.88",
+            "@napi-rs/canvas-darwin-x64": "0.1.88",
+            "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.88",
+            "@napi-rs/canvas-linux-arm64-gnu": "0.1.88",
+            "@napi-rs/canvas-linux-arm64-musl": "0.1.88",
+            "@napi-rs/canvas-linux-riscv64-gnu": "0.1.88",
+            "@napi-rs/canvas-linux-x64-gnu": "0.1.88",
+            "@napi-rs/canvas-linux-x64-musl": "0.1.88",
+            "@napi-rs/canvas-win32-arm64-msvc": "0.1.88",
+            "@napi-rs/canvas-win32-x64-msvc": "0.1.88"
+          }
+        },
+        "@napi-rs/canvas-android-arm64": {
+          "version": "0.1.88",
+          "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.88.tgz",
+          "integrity": "sha512-KEaClPnZuVxJ8smUWjV1wWFkByBO/D+vy4lN+Dm5DFH514oqwukxKGeck9xcKJhaWJGjfruGmYGiwRe//+/zQQ==",
+          "optional": true
+        },
+        "@napi-rs/canvas-darwin-arm64": {
+          "version": "0.1.88",
+          "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.88.tgz",
+          "integrity": "sha512-Xgywz0dDxOKSgx3eZnK85WgGMmGrQEW7ZLA/E7raZdlEE+xXCozobgqz2ZvYigpB6DJFYkqnwHjqCOTSDGlFdg==",
+          "optional": true
+        },
+        "@napi-rs/canvas-darwin-x64": {
+          "version": "0.1.88",
+          "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.88.tgz",
+          "integrity": "sha512-Yz4wSCIQOUgNucgk+8NFtQxQxZV5NO8VKRl9ePKE6XoNyNVC8JDqtvhh3b3TPqKK8W5p2EQpAr1rjjm0mfBxdg==",
+          "optional": true
+        },
+        "@napi-rs/canvas-linux-arm-gnueabihf": {
+          "version": "0.1.88",
+          "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.88.tgz",
+          "integrity": "sha512-9gQM2SlTo76hYhxHi2XxWTAqpTOb+JtxMPEIr+H5nAhHhyEtNmTSDRtz93SP7mGd2G3Ojf2oF5tP9OdgtgXyKg==",
+          "optional": true
+        },
+        "@napi-rs/canvas-linux-arm64-gnu": {
+          "version": "0.1.88",
+          "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.88.tgz",
+          "integrity": "sha512-7qgaOBMXuVRk9Fzztzr3BchQKXDxGbY+nwsovD3I/Sx81e+sX0ReEDYHTItNb0Je4NHbAl7D0MKyd4SvUc04sg==",
+          "optional": true
+        },
+        "@napi-rs/canvas-linux-arm64-musl": {
+          "version": "0.1.88",
+          "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.88.tgz",
+          "integrity": "sha512-kYyNrUsHLkoGHBc77u4Unh067GrfiCUMbGHC2+OTxbeWfZkPt2o32UOQkhnSswKd9Fko/wSqqGkY956bIUzruA==",
+          "optional": true
+        },
+        "@napi-rs/canvas-linux-riscv64-gnu": {
+          "version": "0.1.88",
+          "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.88.tgz",
+          "integrity": "sha512-HVuH7QgzB0yavYdNZDRyAsn/ejoXB0hn8twwFnOqUbCCdkV+REna7RXjSR7+PdfW0qMQ2YYWsLvVBT5iL/mGpw==",
+          "optional": true
+        },
+        "@napi-rs/canvas-linux-x64-gnu": {
+          "version": "0.1.88",
+          "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.88.tgz",
+          "integrity": "sha512-hvcvKIcPEQrvvJtJnwD35B3qk6umFJ8dFIr8bSymfrSMem0EQsfn1ztys8ETIFndTwdNWJKWluvxztA41ivsEw==",
+          "optional": true
+        },
+        "@napi-rs/canvas-linux-x64-musl": {
+          "version": "0.1.88",
+          "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.88.tgz",
+          "integrity": "sha512-eSMpGYY2xnZSQ6UxYJ6plDboxq4KeJ4zT5HaVkUnbObNN6DlbJe0Mclh3wifAmquXfrlgTZt6zhHsUgz++AK6g==",
+          "optional": true
+        },
+        "@napi-rs/canvas-win32-x64-msvc": {
+          "version": "0.1.88",
+          "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.88.tgz",
+          "integrity": "sha512-ROVqbfS4QyZxYkqmaIBBpbz/BQvAR+05FXM5PAtTYVc0uyY8Y4BHJSMdGAaMf6TdIVRsQsiq+FG/dH9XhvWCFQ==",
+          "optional": true
+        }
+      }
     },
     "pg": {
       "version": "8.16.3",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "next": "^16.1.1",
     "next-auth": "^5.0.0-beta.30",
     "openai": "^6.15.0",
+    "pdf-parse": "^2.4.5",
+    "pdfjs-dist": "^5.4.530",
     "pg": "^8.16.3",
     "react": "19.2.0",
     "react-dom": "19.2.0"
@@ -38,6 +40,7 @@
     "@types/bcryptjs": "^2.4.6",
     "@types/canvas-confetti": "^1.9.0",
     "@types/node": "^20",
+    "@types/pdf-parse": "^1.1.5",
     "@types/pg": "^8.15.6",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/src/app/api/recipes/extract-from-pdf/__tests__/route.test.ts
+++ b/src/app/api/recipes/extract-from-pdf/__tests__/route.test.ts
@@ -1,0 +1,411 @@
+/**
+ * Tests for recipe extraction from PDF API route
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from '../route';
+
+// Mock auth
+vi.mock('@/lib/auth', () => ({
+  auth: vi.fn(),
+}));
+
+// Mock recipe-extraction
+vi.mock('@/lib/recipe-extraction', () => ({
+  extractRecipeFromText: vi.fn(),
+  toRecipeJson: vi.fn(),
+}));
+
+// Mock recipes
+vi.mock('@/lib/recipes', () => ({
+  createRecipe: vi.fn(),
+  getUniqueSlug: vi.fn(),
+}));
+
+// Mock recipe-types
+vi.mock('@/lib/recipe-types', () => ({
+  generateSlug: vi.fn(),
+}));
+
+// Mock user-preferences
+vi.mock('@/lib/user-preferences', () => ({
+  getRegionFromTimezone: vi.fn().mockReturnValue('Europe/Vienna'),
+}));
+
+// Mock pdf-utils
+vi.mock('@/lib/pdf-utils', () => ({
+  extractPdfPagesText: vi.fn(),
+  MAX_PDF_PAGES: 50,
+  MIN_TEXT_LENGTH_FOR_TEXT_EXTRACTION: 200,
+}));
+
+import { auth } from '@/lib/auth';
+import { extractRecipeFromText, toRecipeJson } from '@/lib/recipe-extraction';
+import { createRecipe, getUniqueSlug } from '@/lib/recipes';
+import { generateSlug } from '@/lib/recipe-types';
+import { extractPdfPagesText } from '@/lib/pdf-utils';
+
+// Sample extracted data
+const mockExtractedData = {
+  title: 'Test Recipe',
+  description: 'A delicious test recipe',
+  servings: 4,
+  prepTimeMinutes: 10,
+  cookTimeMinutes: 20,
+  locale: 'en-US',
+  tags: ['dinner', 'quick'],
+  nutrition: {
+    calories: 400,
+    protein: 25,
+    carbohydrates: 35,
+    fat: 15,
+  },
+  ingredientGroups: [
+    {
+      name: 'Main',
+      ingredients: [{ name: 'chicken', quantity: 500, unit: 'g' }],
+    },
+  ],
+  steps: [{ number: 1, instruction: 'Cook' }],
+};
+
+// Sample recipe JSON
+const mockRecipeJson = {
+  slug: 'test-recipe',
+  title: 'Test Recipe',
+  description: 'A delicious test recipe',
+  servings: 4,
+  prepTimeMinutes: 10,
+  cookTimeMinutes: 20,
+  locale: 'en-US',
+  tags: ['dinner', 'quick'],
+  nutrition: mockExtractedData.nutrition,
+  ingredientGroups: mockExtractedData.ingredientGroups,
+  steps: mockExtractedData.steps,
+  images: [],
+  sourceType: 'ai_generated',
+};
+
+// Helper to create a mock request
+function createMockRequest(body: Record<string, unknown> | null): Request {
+  return {
+    json: vi.fn().mockResolvedValue(body || {}),
+  } as unknown as Request;
+}
+
+describe('POST /api/recipes/extract-from-pdf', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default to authenticated
+    vi.mocked(auth).mockResolvedValue({
+      user: { id: '123', locale: 'en-US' },
+    } as never);
+    // Default success extraction
+    vi.mocked(extractRecipeFromText).mockResolvedValue({
+      success: true,
+      data: mockExtractedData,
+    });
+    vi.mocked(generateSlug).mockReturnValue('test-recipe');
+    vi.mocked(getUniqueSlug).mockResolvedValue('test-recipe');
+    vi.mocked(toRecipeJson).mockReturnValue(mockRecipeJson);
+    vi.mocked(createRecipe).mockResolvedValue({
+      id: 1,
+      userId: 123,
+      slug: 'test-recipe',
+      version: 1,
+      title: 'Test Recipe',
+      description: 'A delicious test recipe',
+      locale: 'en-US',
+      tags: ['dinner', 'quick'],
+      recipeJson: mockRecipeJson,
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    // Default PDF info with one page with significant text
+    vi.mocked(extractPdfPagesText).mockResolvedValue({
+      pageCount: 1,
+      totalText: 'Recipe content here with more than 200 characters to be considered significant text. This is a test recipe that includes ingredients like flour, sugar, eggs, and butter. Instructions include mixing and baking.',
+      pages: [
+        {
+          pageNumber: 1,
+          textContent: 'Recipe content here with more than 200 characters to be considered significant text. This is a test recipe that includes ingredients like flour, sugar, eggs, and butter. Instructions include mixing and baking.',
+          hasSignificantText: true,
+        },
+      ],
+    });
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when not authenticated', async () => {
+      vi.mocked(auth).mockResolvedValueOnce(null);
+      const request = createMockRequest({ pdfBase64: 'somebase64data' });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error).toBe('Unauthorized');
+    });
+
+    it('returns 401 when session has no user ID', async () => {
+      vi.mocked(auth).mockResolvedValueOnce({ user: {} } as never);
+      const request = createMockRequest({ pdfBase64: 'somebase64data' });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error).toBe('Unauthorized');
+    });
+  });
+
+  describe('input validation', () => {
+    it('returns 400 when no pdfBase64 provided', async () => {
+      const request = createMockRequest({});
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe('No PDF data provided');
+    });
+
+    it('returns 400 when pdfBase64 is not a string', async () => {
+      const request = createMockRequest({ pdfBase64: 123 });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe('No PDF data provided');
+    });
+
+    it('returns 400 when pdfBase64 is too large', async () => {
+      // Create a string larger than 15MB
+      const largeBase64 = 'a'.repeat(16 * 1024 * 1024);
+      const request = createMockRequest({ pdfBase64: largeBase64 });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe('PDF too large. Please use a smaller file.');
+    });
+  });
+
+  describe('PDF parsing errors', () => {
+    it('returns 400 for password-protected PDFs', async () => {
+      vi.mocked(extractPdfPagesText).mockRejectedValueOnce(
+        new Error('password required')
+      );
+      const request = createMockRequest({ pdfBase64: 'somebase64data' });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe('This PDF is password-protected. Please provide an unprotected PDF.');
+    });
+
+    it('returns 400 when PDF has too many pages', async () => {
+      vi.mocked(extractPdfPagesText).mockResolvedValueOnce({
+        pageCount: 51,
+        totalText: '',
+        pages: [],
+      });
+      const request = createMockRequest({ pdfBase64: 'somebase64data' });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe('PDF has too many pages (51). Maximum: 50');
+    });
+  });
+
+  describe('successful extraction', () => {
+    it('returns 201 with single recipe on success', async () => {
+      const request = createMockRequest({ pdfBase64: 'somebase64data' });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(data.recipes).toHaveLength(1);
+      expect(data.recipes[0].slug).toBe('test-recipe');
+      expect(data.extractedCount).toBe(1);
+      expect(data.totalPages).toBe(1);
+    });
+
+    it('returns extracted recipes from multiple pages', async () => {
+      vi.mocked(extractPdfPagesText).mockResolvedValue({
+        pageCount: 2,
+        totalText: 'Page 1 content\n\nPage 2 content',
+        pages: [
+          { pageNumber: 1, textContent: 'A'.repeat(250), hasSignificantText: true },
+          { pageNumber: 2, textContent: 'B'.repeat(250), hasSignificantText: true },
+        ],
+      });
+
+      // Return different recipes for each page
+      vi.mocked(extractRecipeFromText)
+        .mockResolvedValueOnce({
+          success: true,
+          data: { ...mockExtractedData, title: 'Recipe 1' },
+        })
+        .mockResolvedValueOnce({
+          success: true,
+          data: { ...mockExtractedData, title: 'Recipe 2' },
+        });
+
+      vi.mocked(generateSlug)
+        .mockReturnValueOnce('recipe-1')
+        .mockReturnValueOnce('recipe-2');
+
+      vi.mocked(getUniqueSlug)
+        .mockResolvedValueOnce('recipe-1')
+        .mockResolvedValueOnce('recipe-2');
+
+      const request = createMockRequest({ pdfBase64: 'somebase64data' });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(data.recipes).toHaveLength(2);
+      expect(data.extractedCount).toBe(2);
+    });
+
+    it('skips pages without significant text', async () => {
+      vi.mocked(extractPdfPagesText).mockResolvedValue({
+        pageCount: 3,
+        totalText: 'Short text\n\nLong content with more than 200 chars...',
+        pages: [
+          { pageNumber: 1, textContent: 'Table of Contents', hasSignificantText: false },
+          { pageNumber: 2, textContent: 'A'.repeat(250), hasSignificantText: true },
+          { pageNumber: 3, textContent: 'Page 3', hasSignificantText: false },
+        ],
+      });
+
+      const request = createMockRequest({ pdfBase64: 'somebase64data' });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(data.recipes).toHaveLength(1);
+      expect(data.skippedPages).toContain(1);
+      expect(data.skippedPages).toContain(3);
+      expect(data.skippedPages).not.toContain(2);
+    });
+
+    it('skips pages where extraction fails', async () => {
+      vi.mocked(extractPdfPagesText).mockResolvedValue({
+        pageCount: 2,
+        totalText: 'Content',
+        pages: [
+          { pageNumber: 1, textContent: 'A'.repeat(250), hasSignificantText: true },
+          { pageNumber: 2, textContent: 'B'.repeat(250), hasSignificantText: true },
+        ],
+      });
+
+      vi.mocked(extractRecipeFromText)
+        .mockResolvedValueOnce({
+          success: true,
+          data: mockExtractedData,
+        })
+        .mockResolvedValueOnce({
+          success: false,
+          error: 'No recipe found',
+        });
+
+      const request = createMockRequest({ pdfBase64: 'somebase64data' });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(data.recipes).toHaveLength(1);
+      expect(data.skippedPages).toContain(2);
+    });
+
+    it('attempts combined extraction when no recipes found on individual pages', async () => {
+      vi.mocked(extractPdfPagesText).mockResolvedValue({
+        pageCount: 2,
+        totalText: 'Combined recipe content with ingredients and steps spread across pages. ' + 'A'.repeat(200),
+        pages: [
+          { pageNumber: 1, textContent: 'Part 1 short', hasSignificantText: false },
+          { pageNumber: 2, textContent: 'Part 2 short', hasSignificantText: false },
+        ],
+      });
+
+      const request = createMockRequest({ pdfBase64: 'somebase64data' });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(201);
+      // Should have tried combined extraction
+      expect(extractRecipeFromText).toHaveBeenCalledWith(
+        expect.stringContaining('Combined recipe content'),
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe('extraction passes user preferences', () => {
+    it('passes locale and region to extraction', async () => {
+      vi.mocked(auth).mockResolvedValue({
+        user: {
+          id: '123',
+          locale: 'en-US',
+          defaultRecipeLocale: 'de-DE',
+          userRegionTimezone: 'Europe/Vienna',
+        },
+      } as never);
+
+      const request = createMockRequest({ pdfBase64: 'somebase64data' });
+
+      await POST(request);
+
+      expect(extractRecipeFromText).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          targetLocale: 'de-DE',
+        })
+      );
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 500 on unexpected PDF parsing error', async () => {
+      vi.mocked(extractPdfPagesText).mockRejectedValueOnce(
+        new Error('Unexpected error')
+      );
+      const request = createMockRequest({ pdfBase64: 'somebase64data' });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.error).toBe('Failed to process PDF. Please try again.');
+    });
+
+    it('skips page when database error occurs on save', async () => {
+      // Database errors on individual pages are caught and the page is skipped
+      // (for multi-page PDFs, one page failing shouldn't fail the whole request)
+      // Mock createRecipe to always reject to prevent combined text extraction from succeeding
+      vi.mocked(createRecipe).mockRejectedValue(new Error('Database error'));
+      const request = createMockRequest({ pdfBase64: 'somebase64data' });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      // Should return 201 with the failed page in skippedPages
+      expect(response.status).toBe(201);
+      expect(data.skippedPages).toContain(1);
+      expect(data.extractedCount).toBe(0);
+    });
+  });
+});

--- a/src/app/api/recipes/extract-from-pdf/route.ts
+++ b/src/app/api/recipes/extract-from-pdf/route.ts
@@ -1,0 +1,203 @@
+/**
+ * POST /api/recipes/extract-from-pdf
+ * Extract recipes from a PDF file (handles multi-page PDFs)
+ *
+ * Request body:
+ *   - pdfBase64: Base64-encoded PDF data
+ *
+ * Response:
+ *   - Success: { recipes: Array<{slug, title, pageNumber}>, totalPages, extractedCount, skippedPages }
+ *   - Error: { error: string }
+ */
+
+import { auth } from '@/lib/auth';
+import {
+  extractRecipeFromText,
+  toRecipeJson,
+} from '@/lib/recipe-extraction';
+import { createRecipe, getUniqueSlug } from '@/lib/recipes';
+import { generateSlug } from '@/lib/recipe-types';
+import { getRegionFromTimezone } from '@/lib/user-preferences';
+import {
+  extractPdfPagesText,
+  MAX_PDF_PAGES,
+  MIN_TEXT_LENGTH_FOR_TEXT_EXTRACTION,
+} from '@/lib/pdf-utils';
+
+export const runtime = 'nodejs';
+
+// Maximum base64 PDF size (approximately 15MB after base64 encoding of 10MB file)
+const MAX_BASE64_SIZE = 15 * 1024 * 1024;
+
+interface ExtractedRecipeResult {
+  slug: string;
+  title: string;
+  pageNumber: number;
+}
+
+interface ExtractionResponse {
+  recipes: ExtractedRecipeResult[];
+  totalPages: number;
+  extractedCount: number;
+  skippedPages: number[];
+}
+
+export async function POST(request: Request) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const body = await request.json();
+    const { pdfBase64 } = body;
+
+    // Validate input
+    if (!pdfBase64 || typeof pdfBase64 !== 'string') {
+      return Response.json({ error: 'No PDF data provided' }, { status: 400 });
+    }
+
+    if (pdfBase64.length > MAX_BASE64_SIZE) {
+      return Response.json(
+        { error: 'PDF too large. Please use a smaller file.' },
+        { status: 400 }
+      );
+    }
+
+    // Get user preferences
+    const recipeLocale =
+      session.user.defaultRecipeLocale || session.user.locale || 'en-US';
+    const userRegionTimezone =
+      session.user.userRegionTimezone || session.user.timezone || 'UTC';
+    const userRegion = getRegionFromTimezone(userRegionTimezone);
+
+    const userId = session.user.id;
+    const userIdNum = parseInt(userId, 10);
+
+    // Parse PDF
+    const pdfBuffer = Buffer.from(pdfBase64, 'base64');
+
+    let pdfInfo;
+    try {
+      pdfInfo = await extractPdfPagesText(pdfBuffer);
+    } catch (error) {
+      // Handle password-protected PDFs
+      if (error instanceof Error && error.message.includes('password')) {
+        return Response.json(
+          { error: 'This PDF is password-protected. Please provide an unprotected PDF.' },
+          { status: 400 }
+        );
+      }
+      throw error;
+    }
+
+    if (pdfInfo.pageCount > MAX_PDF_PAGES) {
+      return Response.json(
+        { error: `PDF has too many pages (${pdfInfo.pageCount}). Maximum: ${MAX_PDF_PAGES}` },
+        { status: 400 }
+      );
+    }
+
+    const recipes: ExtractedRecipeResult[] = [];
+    const skippedPages: number[] = [];
+
+    // Process each page
+    for (const page of pdfInfo.pages) {
+      try {
+        // Skip pages with insufficient text content
+        if (!page.hasSignificantText) {
+          // Page doesn't have enough text - likely an image-based page or TOC
+          // For now, we skip these pages (future: could render to image and use vision API)
+          skippedPages.push(page.pageNumber);
+          continue;
+        }
+
+        // Use text-based extraction for text-heavy pages
+        const extractionResult = await extractRecipeFromText(page.textContent, {
+          targetLocale: recipeLocale,
+          targetRegion: userRegion,
+        });
+
+        if (!extractionResult.success) {
+          skippedPages.push(page.pageNumber);
+          continue;
+        }
+
+        // Save extracted recipe
+        const extractedData = extractionResult.data;
+        const baseSlug = generateSlug(extractedData.title);
+        const slug = await getUniqueSlug(userIdNum, baseSlug);
+
+        // Build and save recipe (no image for text-based extraction)
+        const recipeJson = toRecipeJson(extractedData, slug);
+
+        await createRecipe({
+          title: extractedData.title,
+          description: extractedData.description,
+          locale: extractedData.locale,
+          tags: extractedData.tags,
+          recipeJson,
+        });
+
+        recipes.push({
+          slug,
+          title: extractedData.title,
+          pageNumber: page.pageNumber,
+        });
+      } catch (pageError) {
+        console.error(`Error processing page ${page.pageNumber}:`, pageError);
+        skippedPages.push(page.pageNumber);
+      }
+    }
+
+    // If no recipes were extracted but we have pages with text, try extracting from combined text
+    if (recipes.length === 0 && pdfInfo.totalText.length >= MIN_TEXT_LENGTH_FOR_TEXT_EXTRACTION) {
+      try {
+        const extractionResult = await extractRecipeFromText(pdfInfo.totalText, {
+          targetLocale: recipeLocale,
+          targetRegion: userRegion,
+        });
+
+        if (extractionResult.success) {
+          const extractedData = extractionResult.data;
+          const baseSlug = generateSlug(extractedData.title);
+          const slug = await getUniqueSlug(userIdNum, baseSlug);
+
+          const recipeJson = toRecipeJson(extractedData, slug);
+
+          await createRecipe({
+            title: extractedData.title,
+            description: extractedData.description,
+            locale: extractedData.locale,
+            tags: extractedData.tags,
+            recipeJson,
+          });
+
+          recipes.push({
+            slug,
+            title: extractedData.title,
+            pageNumber: 0, // Indicates combined extraction
+          });
+        }
+      } catch (error) {
+        console.error('Error extracting from combined text:', error);
+      }
+    }
+
+    const response: ExtractionResponse = {
+      recipes,
+      totalPages: pdfInfo.pageCount,
+      extractedCount: recipes.length,
+      skippedPages,
+    };
+
+    return Response.json(response, { status: 201 });
+  } catch (error) {
+    console.error('Error extracting recipes from PDF:', error);
+
+    return Response.json(
+      { error: 'Failed to process PDF. Please try again.' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/RecipePageHeader.tsx
+++ b/src/components/RecipePageHeader.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { PhotoCaptureModal, type PhotoCaptureResult } from './PhotoCaptureModal';
+import { RecipeImportModal, type RecipeImportResult } from './RecipeImportModal';
 
 const PlusIcon = () => (
   <svg
@@ -42,13 +42,17 @@ export function RecipePageHeader() {
   const router = useRouter();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const handleImageCaptured = (result: PhotoCaptureResult) => {
-    setIsModalOpen(false);
+  const handleImageCaptured = (result: RecipeImportResult) => {
     if (result.type === 'extracted') {
       // AI extraction succeeded - navigate to recipe detail page
+      setIsModalOpen(false);
       router.push(`/recipes/${result.slug}`);
+    } else if (result.type === 'extracted-multiple') {
+      // Multiple recipes extracted from PDF - modal will show results
+      // Don't close modal here, let user navigate from the results
     } else {
       // Fallback: manual creation with uploaded image
+      setIsModalOpen(false);
       router.push(`/recipes/new?image=${encodeURIComponent(result.imageUrl)}`);
     }
   };
@@ -63,8 +67,8 @@ export function RecipePageHeader() {
           <button
             onClick={() => setIsModalOpen(true)}
             className="inline-flex items-center justify-center rounded-xl bg-slate-700 p-2.5 text-slate-100 transition hover:bg-slate-600"
-            aria-label="Import recipe from photo"
-            title="Import from photo"
+            aria-label="Import recipe from photo or PDF"
+            title="Import from photo or PDF"
           >
             <CameraIcon />
           </button>
@@ -78,7 +82,7 @@ export function RecipePageHeader() {
         </div>
       </section>
 
-      <PhotoCaptureModal
+      <RecipeImportModal
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
         onImageCaptured={handleImageCaptured}

--- a/src/components/__tests__/RecipeImportModal.test.tsx
+++ b/src/components/__tests__/RecipeImportModal.test.tsx
@@ -1,11 +1,18 @@
 /**
- * Tests for PhotoCaptureModal component
+ * Tests for RecipeImportModal component
  */
 
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { PhotoCaptureModal } from '../PhotoCaptureModal';
+import { RecipeImportModal } from '../RecipeImportModal';
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(() => ({
+    push: vi.fn(),
+  })),
+}));
 
 // Mock next/image
 vi.mock('next/image', () => ({
@@ -25,12 +32,12 @@ vi.mock('next/image', () => ({
 
 // Mock image-utils
 vi.mock('@/lib/image-utils', () => ({
-  validateImageFile: vi.fn(() => ({ valid: true })),
+  validateImportFile: vi.fn(() => ({ valid: true, fileType: 'image' })),
   resizeImage: vi.fn(() => Promise.resolve(new Blob(['test'], { type: 'image/jpeg' }))),
   MAX_FILE_SIZE_MB: 10,
 }));
 
-import { validateImageFile } from '@/lib/image-utils';
+import { validateImportFile } from '@/lib/image-utils';
 
 // Mock URL.createObjectURL and revokeObjectURL
 const mockCreateObjectURL = vi.fn(() => 'blob:mock-url');
@@ -46,7 +53,7 @@ global.fetch = mockFetch;
 const mockMatchMedia = vi.fn();
 window.matchMedia = mockMatchMedia;
 
-describe('PhotoCaptureModal', () => {
+describe('RecipeImportModal', () => {
   const defaultProps = {
     isOpen: true,
     onClose: vi.fn(),
@@ -55,6 +62,8 @@ describe('PhotoCaptureModal', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset the mock to default behavior
+    vi.mocked(validateImportFile).mockReturnValue({ valid: true, fileType: 'image' });
     // Mock the extraction API response
     mockFetch.mockResolvedValue({
       ok: true,
@@ -74,12 +83,12 @@ describe('PhotoCaptureModal', () => {
 
   describe('rendering', () => {
     it('renders when isOpen is true', () => {
-      render(<PhotoCaptureModal {...defaultProps} />);
+      render(<RecipeImportModal {...defaultProps} />);
       expect(screen.getByText('Import Recipe')).toBeInTheDocument();
     });
 
     it('does not render when isOpen is false', () => {
-      render(<PhotoCaptureModal {...defaultProps} isOpen={false} />);
+      render(<RecipeImportModal {...defaultProps} isOpen={false} />);
       expect(screen.queryByText('Import Recipe')).not.toBeInTheDocument();
     });
 
@@ -89,8 +98,8 @@ describe('PhotoCaptureModal', () => {
         addEventListener: vi.fn(),
         removeEventListener: vi.fn(),
       });
-      render(<PhotoCaptureModal {...defaultProps} />);
-      expect(screen.getByText(/drop image here/i)).toBeInTheDocument();
+      render(<RecipeImportModal {...defaultProps} />);
+      expect(screen.getByText(/drop file here/i)).toBeInTheDocument();
     });
 
     it('renders mobile view with camera and library buttons', () => {
@@ -99,21 +108,21 @@ describe('PhotoCaptureModal', () => {
         addEventListener: vi.fn(),
         removeEventListener: vi.fn(),
       });
-      render(<PhotoCaptureModal {...defaultProps} />);
+      render(<RecipeImportModal {...defaultProps} />);
       expect(screen.getByText('Take Photo')).toBeInTheDocument();
-      expect(screen.getByText('Choose from Library')).toBeInTheDocument();
+      expect(screen.getByText('Choose File')).toBeInTheDocument();
     });
 
     it('renders cancel button', () => {
-      render(<PhotoCaptureModal {...defaultProps} />);
+      render(<RecipeImportModal {...defaultProps} />);
       expect(screen.getByText('Cancel')).toBeInTheDocument();
     });
   });
 
   describe('file selection', () => {
-    it('shows preview after file selection', async () => {
+    it('shows preview after image file selection', async () => {
       const user = userEvent.setup();
-      render(<PhotoCaptureModal {...defaultProps} />);
+      render(<RecipeImportModal {...defaultProps} />);
 
       const file = new File(['test'], 'recipe.jpg', { type: 'image/jpeg' });
       const input = document.querySelector('input[type="file"]') as HTMLInputElement;
@@ -121,14 +130,34 @@ describe('PhotoCaptureModal', () => {
       await user.upload(input, file);
 
       await waitFor(() => {
-        expect(screen.getByText('Review Photo')).toBeInTheDocument();
+        expect(screen.getByText('Review File')).toBeInTheDocument();
         expect(screen.getByTestId('preview-image')).toBeInTheDocument();
       });
     });
 
+    it('shows PDF preview after PDF file selection', async () => {
+      vi.mocked(validateImportFile).mockReturnValue({ valid: true, fileType: 'pdf' });
+      const user = userEvent.setup();
+      render(<RecipeImportModal {...defaultProps} />);
+
+      const file = new File(['test'], 'recipes.pdf', { type: 'application/pdf' });
+      const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+      await user.upload(input, file);
+
+      // Wait for component to update - use waitFor with explicit check
+      await waitFor(() => {
+        // PDF preview should show the import button (indicates preview state)
+        expect(screen.getByRole('button', { name: /import recipe/i })).toBeInTheDocument();
+      });
+
+      // Verify PDF-specific content is shown
+      expect(screen.getByText(/click import to extract recipes/i)).toBeInTheDocument();
+    });
+
     it('shows file name and size in preview', async () => {
       const user = userEvent.setup();
-      render(<PhotoCaptureModal {...defaultProps} />);
+      render(<RecipeImportModal {...defaultProps} />);
 
       const file = new File(['test content'], 'my-recipe.jpg', { type: 'image/jpeg' });
       const input = document.querySelector('input[type="file"]') as HTMLInputElement;
@@ -141,34 +170,28 @@ describe('PhotoCaptureModal', () => {
     });
 
     it('shows error for invalid file type', async () => {
-      const user = userEvent.setup();
-
       // Override mock before render
-      vi.mocked(validateImageFile).mockReturnValue({
+      vi.mocked(validateImportFile).mockReturnValue({
         valid: false,
-        error: 'Invalid file type. Allowed: JPEG, PNG, WebP, GIF, HEIC',
+        error: 'Unsupported file type. Allowed: JPEG, PNG, WebP, GIF, HEIC, or PDF',
       });
 
-      render(<PhotoCaptureModal {...defaultProps} />);
+      render(<RecipeImportModal {...defaultProps} />);
 
-      const file = new File(['test'], 'test.jpg', { type: 'image/jpeg' });
+      const file = new File(['test'], 'test.txt', { type: 'text/plain' });
       const input = document.querySelector('input[type="file"]') as HTMLInputElement;
 
-      await user.upload(input, file);
+      // Use fireEvent.change for more direct control
+      fireEvent.change(input, { target: { files: [file] } });
 
-      await waitFor(() => {
-        expect(screen.getByText(/Invalid file type/i)).toBeInTheDocument();
-      });
-
-      // Reset mock for other tests
-      vi.mocked(validateImageFile).mockReturnValue({ valid: true });
+      await screen.findByText(/Unsupported file type/i);
     });
   });
 
   describe('preview actions', () => {
     async function setupPreview() {
       const user = userEvent.setup();
-      render(<PhotoCaptureModal {...defaultProps} />);
+      render(<RecipeImportModal {...defaultProps} />);
 
       const file = new File(['test'], 'recipe.jpg', { type: 'image/jpeg' });
       const input = document.querySelector('input[type="file"]') as HTMLInputElement;
@@ -176,30 +199,28 @@ describe('PhotoCaptureModal', () => {
       await user.upload(input, file);
 
       await waitFor(() => {
-        expect(screen.getByText('Review Photo')).toBeInTheDocument();
+        expect(screen.getByText('Review File')).toBeInTheDocument();
       });
 
       return user;
     }
 
     it('shows Import Recipe button in preview', async () => {
-      const user = await setupPreview();
-      // Verify we have the button - look for button that contains "Import Recipe" text
+      await setupPreview();
       const importButton = screen.getByRole('button', { name: /import recipe/i });
       expect(importButton).toBeInTheDocument();
-      // Verify button is not disabled
       expect(importButton).not.toBeDisabled();
     });
 
-    it('shows Choose Different Photo button in preview', async () => {
+    it('shows Choose Different File button in preview', async () => {
       await setupPreview();
-      expect(screen.getByRole('button', { name: /choose different photo/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /choose different file/i })).toBeInTheDocument();
     });
 
-    it('resets to initial view when Choose Different Photo is clicked', async () => {
+    it('resets to initial view when Choose Different File is clicked', async () => {
       const user = await setupPreview();
 
-      await user.click(screen.getByRole('button', { name: /choose different photo/i }));
+      await user.click(screen.getByRole('button', { name: /choose different file/i }));
 
       await waitFor(() => {
         expect(screen.getByText('Import Recipe')).toBeInTheDocument();
@@ -210,17 +231,17 @@ describe('PhotoCaptureModal', () => {
     it('revokes object URL when resetting', async () => {
       const user = await setupPreview();
 
-      await user.click(screen.getByRole('button', { name: /choose different photo/i }));
+      await user.click(screen.getByRole('button', { name: /choose different file/i }));
 
       expect(mockRevokeObjectURL).toHaveBeenCalled();
     });
   });
 
-  describe('upload and callback', () => {
+  describe('image upload and callback', () => {
     it('calls onImageCaptured with slug after successful extraction', async () => {
       const onImageCaptured = vi.fn();
       const user = userEvent.setup();
-      render(<PhotoCaptureModal {...defaultProps} onImageCaptured={onImageCaptured} />);
+      render(<RecipeImportModal {...defaultProps} onImageCaptured={onImageCaptured} />);
 
       const file = new File(['test'], 'recipe.jpg', { type: 'image/jpeg' });
       const input = document.querySelector('input[type="file"]') as HTMLInputElement;
@@ -243,7 +264,6 @@ describe('PhotoCaptureModal', () => {
     });
 
     it('shows loading state during extraction', async () => {
-      // Make fetch take some time
       mockFetch.mockImplementationOnce(
         () =>
           new Promise((resolve) =>
@@ -259,7 +279,7 @@ describe('PhotoCaptureModal', () => {
       );
 
       const user = userEvent.setup();
-      render(<PhotoCaptureModal {...defaultProps} />);
+      render(<RecipeImportModal {...defaultProps} />);
 
       const file = new File(['test'], 'recipe.jpg', { type: 'image/jpeg' });
       const input = document.querySelector('input[type="file"]') as HTMLInputElement;
@@ -272,8 +292,6 @@ describe('PhotoCaptureModal', () => {
 
       await user.click(screen.getByRole('button', { name: /import recipe/i }));
 
-      // Should show extracting state
-      // Use getAllByText since there are two elements with this text (button + overlay)
       expect(screen.getAllByText(/extracting/i).length).toBeGreaterThan(0);
     });
 
@@ -284,7 +302,7 @@ describe('PhotoCaptureModal', () => {
       });
 
       const user = userEvent.setup();
-      render(<PhotoCaptureModal {...defaultProps} />);
+      render(<RecipeImportModal {...defaultProps} />);
 
       const file = new File(['test'], 'recipe.jpg', { type: 'image/jpeg' });
       const input = document.querySelector('input[type="file"]') as HTMLInputElement;
@@ -303,11 +321,116 @@ describe('PhotoCaptureModal', () => {
     });
   });
 
+  describe('PDF upload and callback', () => {
+    it('calls PDF API for PDF files', async () => {
+      vi.mocked(validateImportFile).mockReturnValue({ valid: true, fileType: 'pdf' });
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          recipes: [{ slug: 'pdf-recipe', title: 'PDF Recipe', pageNumber: 1 }],
+          totalPages: 1,
+          extractedCount: 1,
+          skippedPages: [],
+        }),
+      });
+
+      const onImageCaptured = vi.fn();
+      const user = userEvent.setup();
+      render(<RecipeImportModal {...defaultProps} onImageCaptured={onImageCaptured} />);
+
+      const file = new File(['test'], 'recipes.pdf', { type: 'application/pdf' });
+      const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+      await user.upload(input, file);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /import recipe/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /import recipe/i }));
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          '/api/recipes/extract-from-pdf',
+          expect.objectContaining({ method: 'POST' })
+        );
+        // Single recipe from PDF should navigate directly
+        expect(onImageCaptured).toHaveBeenCalledWith({ type: 'extracted', slug: 'pdf-recipe' });
+      });
+    });
+
+    it('shows results for multi-recipe PDFs', async () => {
+      vi.mocked(validateImportFile).mockReturnValue({ valid: true, fileType: 'pdf' });
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          recipes: [
+            { slug: 'recipe-1', title: 'Recipe 1', pageNumber: 1 },
+            { slug: 'recipe-2', title: 'Recipe 2', pageNumber: 2 },
+          ],
+          totalPages: 2,
+          extractedCount: 2,
+          skippedPages: [],
+        }),
+      });
+
+      const user = userEvent.setup();
+      render(<RecipeImportModal {...defaultProps} />);
+
+      const file = new File(['test'], 'recipes.pdf', { type: 'application/pdf' });
+      const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+      await user.upload(input, file);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /import recipe/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /import recipe/i }));
+
+      // Wait for import results - use findByText for async lookups
+      await screen.findByText('Recipe 1');
+      await screen.findByText('Recipe 2');
+      // Check that the "Done" button appears (indicates import results view)
+      expect(screen.getByRole('button', { name: /done/i })).toBeInTheDocument();
+    });
+
+    it('shows error when no recipes found in PDF', async () => {
+      vi.mocked(validateImportFile).mockReturnValue({ valid: true, fileType: 'pdf' });
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          recipes: [],
+          totalPages: 1,
+          extractedCount: 0,
+          skippedPages: [1],
+        }),
+      });
+
+      const user = userEvent.setup();
+      render(<RecipeImportModal {...defaultProps} />);
+
+      const file = new File(['test'], 'empty.pdf', { type: 'application/pdf' });
+      const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+      await user.upload(input, file);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /import recipe/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /import recipe/i }));
+
+      // Error message should appear
+      await screen.findByText(/no recipes found in the pdf/i);
+    });
+  });
+
   describe('modal actions', () => {
     it('calls onClose when close button is clicked', async () => {
       const onClose = vi.fn();
       const user = userEvent.setup();
-      render(<PhotoCaptureModal {...defaultProps} onClose={onClose} />);
+      render(<RecipeImportModal {...defaultProps} onClose={onClose} />);
 
       await user.click(screen.getByLabelText('Close'));
 
@@ -317,7 +440,7 @@ describe('PhotoCaptureModal', () => {
     it('calls onClose when Cancel is clicked', async () => {
       const onClose = vi.fn();
       const user = userEvent.setup();
-      render(<PhotoCaptureModal {...defaultProps} onClose={onClose} />);
+      render(<RecipeImportModal {...defaultProps} onClose={onClose} />);
 
       await user.click(screen.getByText('Cancel'));
 
@@ -327,9 +450,8 @@ describe('PhotoCaptureModal', () => {
     it('calls onClose when backdrop is clicked', async () => {
       const onClose = vi.fn();
       const user = userEvent.setup();
-      render(<PhotoCaptureModal {...defaultProps} onClose={onClose} />);
+      render(<RecipeImportModal {...defaultProps} onClose={onClose} />);
 
-      // Find the backdrop (the div with bg-black/50)
       const backdrop = document.querySelector('.bg-black\\/50');
       await user.click(backdrop!);
 
@@ -340,62 +462,55 @@ describe('PhotoCaptureModal', () => {
   describe('drag and drop (desktop)', () => {
     beforeEach(() => {
       mockMatchMedia.mockReturnValue({
-        matches: true, // isDesktop = true
+        matches: true,
         addEventListener: vi.fn(),
         removeEventListener: vi.fn(),
       });
     });
 
     it('shows drag over state on dragOver', () => {
-      render(<PhotoCaptureModal {...defaultProps} />);
+      render(<RecipeImportModal {...defaultProps} />);
 
-      const dropZone = screen.getByText(/drop image here/i).closest('div[class*="border-dashed"]');
+      const dropZone = screen.getByText(/drop file here/i).closest('div[class*="border-dashed"]');
       fireEvent.dragOver(dropZone!);
 
       expect(dropZone).toHaveClass('border-emerald-500');
     });
 
     it('removes drag over state on dragLeave', () => {
-      render(<PhotoCaptureModal {...defaultProps} />);
+      render(<RecipeImportModal {...defaultProps} />);
 
-      const dropZone = screen.getByText(/drop image here/i).closest('div[class*="border-dashed"]');
+      const dropZone = screen.getByText(/drop file here/i).closest('div[class*="border-dashed"]');
       fireEvent.dragOver(dropZone!);
       expect(dropZone).toHaveClass('border-emerald-500');
 
       fireEvent.dragLeave(dropZone!);
       expect(dropZone).not.toHaveClass('border-emerald-500');
     });
-
-    // Note: Testing actual file drop behavior is challenging in JSDOM
-    // because DataTransfer.files doesn't behave like a proper FileList.
-    // The core upload flow is tested via file input selection tests.
-    // The drag-over visual feedback is tested above.
   });
 
   describe('mobile view', () => {
     beforeEach(() => {
       mockMatchMedia.mockReturnValue({
-        matches: false, // isDesktop = false
+        matches: false,
         addEventListener: vi.fn(),
         removeEventListener: vi.fn(),
       });
     });
 
     it('has camera input with capture attribute', () => {
-      render(<PhotoCaptureModal {...defaultProps} />);
+      render(<RecipeImportModal {...defaultProps} />);
 
       const cameraInput = document.querySelector('input[capture="environment"]');
       expect(cameraInput).toBeInTheDocument();
     });
 
     it('has regular file input for library', () => {
-      render(<PhotoCaptureModal {...defaultProps} />);
+      render(<RecipeImportModal {...defaultProps} />);
 
-      // There should be 2 file inputs - one with capture and one without
       const fileInputs = document.querySelectorAll('input[type="file"]');
       expect(fileInputs.length).toBe(2);
 
-      // One should have capture attribute, one should not
       const withCapture = Array.from(fileInputs).filter(
         (input) => input.hasAttribute('capture')
       );

--- a/src/lib/__tests__/pdf-utils.test.ts
+++ b/src/lib/__tests__/pdf-utils.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Tests for PDF utilities
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  validatePdfFile,
+  validatePdfBase64Size,
+  MAX_PDF_SIZE_MB,
+  MAX_PDF_SIZE_BYTES,
+  MAX_PDF_PAGES,
+  MIN_TEXT_LENGTH_FOR_TEXT_EXTRACTION,
+} from '../pdf-utils';
+import { createMockFile } from './fixtures/recipe-fixtures';
+
+// Mock pdf-parse
+vi.mock('pdf-parse', () => ({
+  default: vi.fn(),
+}));
+
+// Mock pdfjs-dist
+vi.mock('pdfjs-dist/legacy/build/pdf.mjs', () => ({
+  getDocument: vi.fn(),
+}));
+
+describe('pdf-utils', () => {
+  describe('validatePdfFile', () => {
+    it('accepts valid PDF files', () => {
+      const file = createMockFile('test.pdf', 'application/pdf', 1024);
+      const result = validatePdfFile(file);
+      expect(result.valid).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    it('rejects non-PDF files', () => {
+      const file = createMockFile('test.jpg', 'image/jpeg', 1024);
+      const result = validatePdfFile(file);
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('Invalid file type. Expected PDF.');
+    });
+
+    it('rejects files that are too large', () => {
+      const file = createMockFile('test.pdf', 'application/pdf', MAX_PDF_SIZE_BYTES + 1);
+      const result = validatePdfFile(file);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('PDF too large');
+      expect(result.error).toContain(`${MAX_PDF_SIZE_MB}MB`);
+    });
+
+    it('accepts files at exactly the size limit', () => {
+      const file = createMockFile('test.pdf', 'application/pdf', MAX_PDF_SIZE_BYTES);
+      const result = validatePdfFile(file);
+      expect(result.valid).toBe(true);
+    });
+
+    it('rejects text files with PDF extension', () => {
+      const file = createMockFile('test.pdf', 'text/plain', 1024);
+      const result = validatePdfFile(file);
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('Invalid file type. Expected PDF.');
+    });
+  });
+
+  describe('validatePdfBase64Size', () => {
+    it('accepts base64 strings within size limit', () => {
+      // 1KB of base64 data (approximately 750 bytes binary)
+      const base64 = 'A'.repeat(1000);
+      const result = validatePdfBase64Size(base64);
+      expect(result.valid).toBe(true);
+    });
+
+    it('rejects base64 strings that are too large', () => {
+      // Create base64 string that would exceed 10MB when decoded
+      // Base64 is ~33% larger than binary, so ~14MB base64 = ~10.5MB binary
+      const base64 = 'A'.repeat(14 * 1024 * 1024);
+      const result = validatePdfBase64Size(base64);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('PDF too large');
+    });
+  });
+
+  describe('constants', () => {
+    it('exports MAX_PDF_SIZE_MB as 10', () => {
+      expect(MAX_PDF_SIZE_MB).toBe(10);
+    });
+
+    it('exports MAX_PDF_SIZE_BYTES correctly calculated', () => {
+      expect(MAX_PDF_SIZE_BYTES).toBe(10 * 1024 * 1024);
+    });
+
+    it('exports MAX_PDF_PAGES as 50', () => {
+      expect(MAX_PDF_PAGES).toBe(50);
+    });
+
+    it('exports MIN_TEXT_LENGTH_FOR_TEXT_EXTRACTION as 200', () => {
+      expect(MIN_TEXT_LENGTH_FOR_TEXT_EXTRACTION).toBe(200);
+    });
+  });
+});
+
+describe('extractPdfText', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('extracts text from a valid PDF buffer', async () => {
+    const { default: pdfParse } = await import('pdf-parse');
+    (pdfParse as ReturnType<typeof vi.fn>).mockResolvedValue({
+      numpages: 2,
+      text: 'Page 1 content\n\nPage 2 content',
+    });
+
+    const { extractPdfText } = await import('../pdf-utils');
+    const buffer = Buffer.from('fake pdf content');
+    const result = await extractPdfText(buffer);
+
+    expect(result.pageCount).toBe(2);
+    expect(result.totalText).toBe('Page 1 content\n\nPage 2 content');
+  });
+
+  it('throws error when PDF has too many pages', async () => {
+    const { default: pdfParse } = await import('pdf-parse');
+    (pdfParse as ReturnType<typeof vi.fn>).mockResolvedValue({
+      numpages: 51,
+      text: 'Too many pages',
+    });
+
+    const { extractPdfText } = await import('../pdf-utils');
+    const buffer = Buffer.from('fake pdf content');
+
+    await expect(extractPdfText(buffer)).rejects.toThrow('PDF has too many pages (51). Maximum: 50');
+  });
+});
+
+describe('extractPdfPagesText', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('extracts text from each page of a PDF', async () => {
+    const mockTextContent = {
+      items: [
+        { str: 'Hello' },
+        { str: ' ' },
+        { str: 'World' },
+      ],
+    };
+
+    const mockPage = {
+      getTextContent: vi.fn().mockResolvedValue(mockTextContent),
+    };
+
+    const mockPdfDoc = {
+      numPages: 2,
+      getPage: vi.fn().mockResolvedValue(mockPage),
+    };
+
+    const pdfjsLib = await import('pdfjs-dist/legacy/build/pdf.mjs');
+    (pdfjsLib.getDocument as ReturnType<typeof vi.fn>).mockReturnValue({
+      promise: Promise.resolve(mockPdfDoc),
+    });
+
+    const { extractPdfPagesText } = await import('../pdf-utils');
+    const buffer = Buffer.from('fake pdf content');
+    const result = await extractPdfPagesText(buffer);
+
+    expect(result.pageCount).toBe(2);
+    expect(result.pages).toHaveLength(2);
+    expect(result.pages[0].pageNumber).toBe(1);
+    expect(result.pages[0].textContent).toBe('Hello   World');
+    expect(result.pages[0].hasSignificantText).toBe(false); // Less than 200 chars
+  });
+
+  it('marks pages with significant text appropriately', async () => {
+    const longText = 'A'.repeat(250);
+    const mockTextContent = {
+      items: [{ str: longText }],
+    };
+
+    const mockPage = {
+      getTextContent: vi.fn().mockResolvedValue(mockTextContent),
+    };
+
+    const mockPdfDoc = {
+      numPages: 1,
+      getPage: vi.fn().mockResolvedValue(mockPage),
+    };
+
+    const pdfjsLib = await import('pdfjs-dist/legacy/build/pdf.mjs');
+    (pdfjsLib.getDocument as ReturnType<typeof vi.fn>).mockReturnValue({
+      promise: Promise.resolve(mockPdfDoc),
+    });
+
+    const { extractPdfPagesText } = await import('../pdf-utils');
+    const buffer = Buffer.from('fake pdf content');
+    const result = await extractPdfPagesText(buffer);
+
+    expect(result.pages[0].hasSignificantText).toBe(true);
+  });
+
+  it('throws error when PDF has too many pages', async () => {
+    const mockPdfDoc = {
+      numPages: 51,
+      getPage: vi.fn(),
+    };
+
+    const pdfjsLib = await import('pdfjs-dist/legacy/build/pdf.mjs');
+    (pdfjsLib.getDocument as ReturnType<typeof vi.fn>).mockReturnValue({
+      promise: Promise.resolve(mockPdfDoc),
+    });
+
+    const { extractPdfPagesText } = await import('../pdf-utils');
+    const buffer = Buffer.from('fake pdf content');
+
+    await expect(extractPdfPagesText(buffer)).rejects.toThrow('PDF has too many pages (51). Maximum: 50');
+  });
+});
+
+describe('extractPageText', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('extracts text from a specific page', async () => {
+    const mockTextContent = {
+      items: [
+        { str: 'Page' },
+        { str: ' ' },
+        { str: '2' },
+      ],
+    };
+
+    const mockPage = {
+      getTextContent: vi.fn().mockResolvedValue(mockTextContent),
+    };
+
+    const mockPdfDoc = {
+      numPages: 3,
+      getPage: vi.fn().mockResolvedValue(mockPage),
+    };
+
+    const pdfjsLib = await import('pdfjs-dist/legacy/build/pdf.mjs');
+    (pdfjsLib.getDocument as ReturnType<typeof vi.fn>).mockReturnValue({
+      promise: Promise.resolve(mockPdfDoc),
+    });
+
+    const { extractPageText } = await import('../pdf-utils');
+    const buffer = Buffer.from('fake pdf content');
+    const result = await extractPageText(buffer, 2);
+
+    expect(result).toBe('Page   2');
+    expect(mockPdfDoc.getPage).toHaveBeenCalledWith(2);
+  });
+
+  it('throws error for invalid page number (too low)', async () => {
+    const mockPdfDoc = {
+      numPages: 3,
+      getPage: vi.fn(),
+    };
+
+    const pdfjsLib = await import('pdfjs-dist/legacy/build/pdf.mjs');
+    (pdfjsLib.getDocument as ReturnType<typeof vi.fn>).mockReturnValue({
+      promise: Promise.resolve(mockPdfDoc),
+    });
+
+    const { extractPageText } = await import('../pdf-utils');
+    const buffer = Buffer.from('fake pdf content');
+
+    await expect(extractPageText(buffer, 0)).rejects.toThrow('Invalid page number: 0. PDF has 3 pages.');
+  });
+
+  it('throws error for invalid page number (too high)', async () => {
+    const mockPdfDoc = {
+      numPages: 3,
+      getPage: vi.fn(),
+    };
+
+    const pdfjsLib = await import('pdfjs-dist/legacy/build/pdf.mjs');
+    (pdfjsLib.getDocument as ReturnType<typeof vi.fn>).mockReturnValue({
+      promise: Promise.resolve(mockPdfDoc),
+    });
+
+    const { extractPageText } = await import('../pdf-utils');
+    const buffer = Buffer.from('fake pdf content');
+
+    await expect(extractPageText(buffer, 5)).rejects.toThrow('Invalid page number: 5. PDF has 3 pages.');
+  });
+});
+
+describe('getPdfPageCount', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the page count of a PDF', async () => {
+    const { default: pdfParse } = await import('pdf-parse');
+    (pdfParse as ReturnType<typeof vi.fn>).mockResolvedValue({
+      numpages: 5,
+      text: 'Some text',
+    });
+
+    const { getPdfPageCount } = await import('../pdf-utils');
+    const buffer = Buffer.from('fake pdf content');
+    const count = await getPdfPageCount(buffer);
+
+    expect(count).toBe(5);
+  });
+});

--- a/src/lib/__tests__/recipe-extraction.test.ts
+++ b/src/lib/__tests__/recipe-extraction.test.ts
@@ -5,6 +5,9 @@ import {
   type ExtractedRecipeData,
 } from '../recipe-extraction';
 
+// Note: extractRecipeFromText tests are covered by API route tests
+// The function uses lazy-initialized OpenAI which is difficult to mock in unit tests
+
 describe('parseExtractionResponse', () => {
   it('successfully parses a complete recipe response', () => {
     const rawResponse = {

--- a/src/lib/image-utils.ts
+++ b/src/lib/image-utils.ts
@@ -18,9 +18,21 @@ export const ALLOWED_IMAGE_TYPES = [
   'image/heif',
 ];
 
+// Allowed PDF types
+export const ALLOWED_PDF_TYPES = ['application/pdf'];
+
+// File type discriminator
+export type ImportFileType = 'image' | 'pdf';
+
 export interface ImageValidationResult {
   valid: boolean;
   error?: string;
+}
+
+export interface ImportFileValidationResult {
+  valid: boolean;
+  error?: string;
+  fileType?: ImportFileType;
 }
 
 /**
@@ -122,4 +134,31 @@ export async function resizeImage(file: File): Promise<Blob> {
 export function generateImageId(): string {
   // Use crypto.randomUUID() for robust, collision-resistant ID generation
   return crypto.randomUUID();
+}
+
+/**
+ * Validate a file for recipe import (supports both images and PDFs)
+ */
+export function validateImportFile(file: File): ImportFileValidationResult {
+  const isImage = ALLOWED_IMAGE_TYPES.includes(file.type);
+  const isPdf = ALLOWED_PDF_TYPES.includes(file.type);
+
+  if (!isImage && !isPdf) {
+    return {
+      valid: false,
+      error: 'Unsupported file type. Allowed: JPEG, PNG, WebP, GIF, HEIC, or PDF',
+    };
+  }
+
+  if (file.size > MAX_FILE_SIZE_BYTES) {
+    return {
+      valid: false,
+      error: `File too large. Maximum size: ${MAX_FILE_SIZE_MB}MB`,
+    };
+  }
+
+  return {
+    valid: true,
+    fileType: isPdf ? 'pdf' : 'image',
+  };
 }


### PR DESCRIPTION
## Summary

This PR implements PDF import support for recipe extraction, closing #190. Users can now import recipes from PDF cookbooks and recipe documents in addition to photos.

### Key Changes

- **PDF Processing**: Added `pdf-parse` and `pdfjs-dist` dependencies for PDF text extraction
- **PDF Utilities** (`src/lib/pdf-utils.ts`): New module with PDF validation and page-by-page text extraction
- **Text Extraction** (`src/lib/recipe-extraction.ts`): Added `extractRecipeFromText()` function for GPT-4 text-based recipe extraction
- **API Endpoint** (`/api/recipes/extract-from-pdf`): New endpoint that processes multi-page PDFs, extracting recipes from each page
- **UI Component** (`RecipeImportModal.tsx`): Renamed from `PhotoCaptureModal`, now supports both images and PDFs
  - Shows PDF icon and file info when PDF is selected
  - Displays multi-recipe results for PDFs with multiple recipes
  - Updated file type message: "JPEG, PNG, WebP, GIF, HEIC, or PDF up to 10MB"

### Multi-Page PDF Handling

- Each page is processed independently for recipe extraction
- Pages without significant text content are skipped
- If no recipes found on individual pages, attempts combined text extraction
- Results show which recipes came from which page

### Testing

- ✅ Unit tests for PDF utilities (20 tests)
- ✅ Unit tests for PDF API endpoint (15 tests)
- ✅ Unit tests for RecipeImportModal component (26 tests)
- ✅ All 1251 unit tests passing
- ✅ All 117 E2E tests passing
- ✅ Manual testing via Playwright MCP

## Test Plan

- [ ] Upload a single-page PDF recipe - should extract and navigate to recipe
- [ ] Upload a multi-page PDF cookbook - should show list of extracted recipes
- [ ] Upload a PDF with no recipe content - should show appropriate error
- [ ] Upload an image file - should work as before
- [ ] Verify file size validation (max 10MB)
- [ ] Verify page count validation (max 50 pages)
- [ ] Test password-protected PDF handling

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)