### PR TITLE
fix: convert Buffer to Uint8Array for pdfjs-dist compatibility

### DIFF
--- a/src/lib/pdf-utils.ts
+++ b/src/lib/pdf-utils.ts
@@ -89,8 +89,9 @@ export async function extractPdfPagesText(pdfBuffer: Buffer): Promise<PdfInfo> {
   // Dynamic import to avoid issues with pdfjs-dist worker
   const pdfjsLib = await import('pdfjs-dist/legacy/build/pdf.mjs');
 
-  // Load the PDF
-  const loadingTask = pdfjsLib.getDocument({ data: pdfBuffer });
+  // Load the PDF - convert Buffer to Uint8Array for pdfjs-dist compatibility
+  const pdfData = new Uint8Array(pdfBuffer);
+  const loadingTask = pdfjsLib.getDocument({ data: pdfData });
   const pdfDoc = await loadingTask.promise;
 
   if (pdfDoc.numPages > MAX_PDF_PAGES) {
@@ -140,7 +141,9 @@ export async function extractPageText(
 ): Promise<string> {
   const pdfjsLib = await import('pdfjs-dist/legacy/build/pdf.mjs');
 
-  const loadingTask = pdfjsLib.getDocument({ data: pdfBuffer });
+  // Convert Buffer to Uint8Array for pdfjs-dist compatibility
+  const pdfData = new Uint8Array(pdfBuffer);
+  const loadingTask = pdfjsLib.getDocument({ data: pdfData });
   const pdfDoc = await loadingTask.promise;
 
   if (pageNumber < 1 || pageNumber > pdfDoc.numPages) {


### PR DESCRIPTION
## Summary
- Fixes PDF recipe import failing with 500 error due to Buffer/Uint8Array type mismatch
- `pdfjs-dist` v5.x requires `Uint8Array`, not Node.js `Buffer`
- Added conversion in `extractPdfPagesText()` and `extractPageText()` functions

## Root Cause
The error message was: `"Please provide binary data as Uint8Array, rather than Buffer"`

While `Buffer` technically extends `Uint8Array` in Node.js, `pdfjs-dist` performs strict type checking that rejects `Buffer` instances.

## The Fix
```typescript
// Before:
const loadingTask = pdfjsLib.getDocument({ data: pdfBuffer });

// After:
const pdfData = new Uint8Array(pdfBuffer);
const loadingTask = pdfjsLib.getDocument({ data: pdfData });
```

## Test plan
- [x] Unit tests pass (1251 tests)
- [x] Build succeeds
- [x] Lint passes
- [x] Direct verification that old behavior throws the exact error
- [x] Direct verification that new behavior works correctly

## Verification
```
Testing OLD behavior (passing Buffer directly)...
OLD behavior error (expected): Please provide binary data as `Uint8Array`, rather than `Buffer`.

Testing NEW behavior (converting to Uint8Array)...
NEW behavior worked! 2 pages
```

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)