### PR TITLE
fix: prevent 400 errors from exercise images by pre-checking availability

### DIFF
--- a/src/app/workouts/[slug]/page.tsx
+++ b/src/app/workouts/[slug]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { getWorkoutBySlug, getTodayCompletions, getTodaySlug } from "@/lib/workoutPlan";
+import { getExercisesWithCompleteImages, normalizeExerciseName } from "@/lib/exercise-library";
 import { PageContextSetter } from "@/components/PageContextSetter";
 import { ExerciseImages } from "@/components/ExerciseImages";
 
@@ -77,6 +78,12 @@ export default async function WorkoutDetailPage({ params }: WorkoutPageProps) {
   const isToday = slug === todaySlug;
   const isCompleted = completions[workout.slug] ?? false;
   const groupedSegments = groupSegments(workout.segments);
+
+  // Fetch which exercises have images available to prevent 400 errors
+  const exerciseNames = workout.segments
+    .filter(s => s.category !== 'rest' && s.category !== 'prep')
+    .map(s => s.title);
+  const availableImages = await getExercisesWithCompleteImages(exerciseNames);
 
   return (
     <>
@@ -162,6 +169,7 @@ export default async function WorkoutDetailPage({ params }: WorkoutPageProps) {
                             exerciseName={segment.title}
                             size="md"
                             className="hidden sm:block"
+                            hasImages={availableImages.has(normalizeExerciseName(segment.title))}
                           />
                         )}
                         <div className="flex flex-1 flex-col gap-2">

--- a/src/app/workouts/[slug]/play/page.tsx
+++ b/src/app/workouts/[slug]/play/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import { GuidedRoutinePlayer } from "@/components/GuidedRoutinePlayer";
 import { getWorkoutBySlug } from "@/lib/workoutPlan";
+import { getExercisesWithCompleteImages } from "@/lib/exercise-library";
 
 export const dynamic = "force-dynamic";
 
@@ -36,5 +37,11 @@ export default async function PlayPage({ params }: PlayPageProps) {
     notFound();
   }
 
-  return <GuidedRoutinePlayer workout={workout} />;
+  // Fetch which exercises have images available to prevent 400 errors
+  const exerciseNames = workout.segments
+    .filter(s => s.category !== 'rest' && s.category !== 'prep')
+    .map(s => s.title);
+  const availableImages = await getExercisesWithCompleteImages(exerciseNames);
+
+  return <GuidedRoutinePlayer workout={workout} availableImages={availableImages} />;
 }

--- a/src/components/GuidedRoutinePlayer.tsx
+++ b/src/components/GuidedRoutinePlayer.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import { useChat } from "@/contexts/ChatContext";
 import { useFullscreen } from "@/lib/fullscreen";
 import { Confetti } from "./Confetti";
-import { ExerciseImages, ExerciseImageThumbnail } from "./ExerciseImages";
+import { ExerciseImages, ExerciseImageThumbnail, normalizeForUrl } from "./ExerciseImages";
 
 import type {
   RoutineSegment,
@@ -45,6 +45,7 @@ const CollapseIcon = () => (
 type GuidedRoutinePlayerProps = {
   workout: PlayableWorkout;
   isNano?: boolean;
+  availableImages?: Set<string>; // Normalized names of exercises with complete images
 };
 
 type CategoryStyles = {
@@ -94,8 +95,16 @@ function sumDuration(segments: RoutineSegment[], endIndex: number) {
 export function GuidedRoutinePlayer({
   workout,
   isNano = false,
+  availableImages,
 }: GuidedRoutinePlayerProps) {
   const { openChat } = useChat();
+
+  // Helper to check if an exercise has images available
+  const hasImages = useCallback((exerciseName: string) => {
+    // If availableImages is not provided, default to true (backward compatible)
+    if (!availableImages) return true;
+    return availableImages.has(normalizeForUrl(exerciseName));
+  }, [availableImages]);
   const segments = useMemo(() => workout.segments ?? [], [workout.segments]);
   const totalSeconds = useMemo(() => workout.totalSeconds ?? 0, [workout.totalSeconds]);
   const routineTitle = workout.title;
@@ -443,6 +452,7 @@ export function GuidedRoutinePlayer({
               <ExerciseImages
                 exerciseName={currentSegment.title}
                 size="lg"
+                hasImages={hasImages(currentSegment.title)}
               />
             )}
             <div className="flex-1 space-y-3">
@@ -537,6 +547,7 @@ export function GuidedRoutinePlayer({
                             {segment.category !== 'prep' && segment.category !== 'rest' && (
                               <ExerciseImageThumbnail
                                 exerciseName={segment.title}
+                                hasImages={hasImages(segment.title)}
                               />
                             )}
                             <div className="flex flex-1 items-center justify-between gap-3">

--- a/src/components/__tests__/ExerciseImages.test.tsx
+++ b/src/components/__tests__/ExerciseImages.test.tsx
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { ExerciseImages, ExerciseImageThumbnail } from '../ExerciseImages';
+import { ExerciseImages, ExerciseImageThumbnail, normalizeForUrl } from '../ExerciseImages';
 
 // Mock Next.js Image component
 vi.mock('next/image', () => ({
@@ -140,5 +140,104 @@ describe('ExerciseImageThumbnail', () => {
       const img = screen.getByTestId('next-image');
       expect(img).toHaveAttribute('src', '/api/exercises/push-ups/images/1');
     });
+  });
+
+  describe('hasImages prop', () => {
+    it('renders nothing when hasImages is false', () => {
+      const { container } = render(
+        <ExerciseImageThumbnail exerciseName="Push ups" hasImages={false} />
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders image when hasImages is true', () => {
+      render(<ExerciseImageThumbnail exerciseName="Push ups" hasImages={true} />);
+
+      const img = screen.getByTestId('next-image');
+      expect(img).toBeInTheDocument();
+    });
+
+    it('renders image by default when hasImages is not provided', () => {
+      render(<ExerciseImageThumbnail exerciseName="Push ups" />);
+
+      const img = screen.getByTestId('next-image');
+      expect(img).toBeInTheDocument();
+    });
+  });
+});
+
+// ============================================
+// normalizeForUrl function tests
+// ============================================
+
+describe('normalizeForUrl', () => {
+  it('converts to lowercase', () => {
+    expect(normalizeForUrl('Push Up')).toBe('push-up');
+    expect(normalizeForUrl('BURPEES')).toBe('burpees');
+  });
+
+  it('replaces spaces with hyphens', () => {
+    expect(normalizeForUrl('jumping jacks')).toBe('jumping-jacks');
+  });
+
+  it('removes special characters', () => {
+    expect(normalizeForUrl('push-up (modified)')).toBe('push-up-modified');
+    expect(normalizeForUrl('90° leg raise')).toBe('90-leg-raise');
+  });
+
+  it('handles multiple consecutive spaces', () => {
+    expect(normalizeForUrl('mountain  climbers')).toBe('mountain-climbers');
+  });
+
+  it('converts leading/trailing spaces to hyphens', () => {
+    // .trim() is called after spaces are replaced with hyphens,
+    // so leading/trailing spaces become leading/trailing hyphens
+    expect(normalizeForUrl('  squats  ')).toBe('-squats-');
+  });
+
+  it('truncates names longer than 255 characters', () => {
+    const longName = 'a'.repeat(300);
+    const result = normalizeForUrl(longName);
+    expect(result.length).toBe(255);
+  });
+
+  it('does not truncate names at or under 255 characters', () => {
+    const exactName = 'a'.repeat(255);
+    const result = normalizeForUrl(exactName);
+    expect(result.length).toBe(255);
+    expect(result).toBe(exactName);
+  });
+});
+
+// ============================================
+// hasImages prop tests for ExerciseImages
+// ============================================
+
+describe('ExerciseImages hasImages prop', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing when hasImages is false', () => {
+    const { container } = render(
+      <ExerciseImages exerciseName="Push ups" hasImages={false} />
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders image when hasImages is true', () => {
+    render(<ExerciseImages exerciseName="Push ups" hasImages={true} />);
+
+    const img = screen.getByTestId('next-image');
+    expect(img).toBeInTheDocument();
+  });
+
+  it('renders image by default when hasImages is not provided', () => {
+    render(<ExerciseImages exerciseName="Push ups" />);
+
+    const img = screen.getByTestId('next-image');
+    expect(img).toBeInTheDocument();
   });
 });

--- a/src/lib/__tests__/exercise-library.test.ts
+++ b/src/lib/__tests__/exercise-library.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for exercise library functions
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  normalizeExerciseName,
+  getExercisesWithCompleteImages,
+} from '../exercise-library';
+
+// Mock database
+vi.mock('../db', () => ({
+  query: vi.fn(),
+}));
+
+import { query } from '../db';
+
+describe('exercise-library', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ============================================
+  // normalizeExerciseName Tests
+  // ============================================
+
+  describe('normalizeExerciseName', () => {
+    it('converts to lowercase', () => {
+      expect(normalizeExerciseName('Push Up')).toBe('push-up');
+      expect(normalizeExerciseName('BURPEES')).toBe('burpees');
+    });
+
+    it('replaces spaces with hyphens', () => {
+      expect(normalizeExerciseName('jumping jacks')).toBe('jumping-jacks');
+      expect(normalizeExerciseName('mountain  climbers')).toBe('mountain-climbers');
+    });
+
+    it('removes special characters', () => {
+      expect(normalizeExerciseName('push-up (modified)')).toBe('push-up-modified');
+      expect(normalizeExerciseName('90° leg raise')).toBe('90-leg-raise');
+    });
+
+    it('converts leading/trailing spaces to hyphens', () => {
+      // .trim() is called after spaces are replaced with hyphens,
+      // so leading/trailing spaces become leading/trailing hyphens
+      expect(normalizeExerciseName('  squats  ')).toBe('-squats-');
+    });
+
+    it('handles multiple transformations', () => {
+      // Leading/trailing spaces become hyphens after replace
+      expect(normalizeExerciseName(' Push Up (Incline) ')).toBe('-push-up-incline-');
+    });
+
+    it('truncates names longer than 255 characters', () => {
+      const longName = 'a'.repeat(300);
+      const result = normalizeExerciseName(longName);
+      expect(result.length).toBe(255);
+    });
+
+    it('does not truncate names at or under 255 characters', () => {
+      const exactName = 'a'.repeat(255);
+      const result = normalizeExerciseName(exactName);
+      expect(result.length).toBe(255);
+      expect(result).toBe(exactName);
+    });
+  });
+
+  // ============================================
+  // getExercisesWithCompleteImages Tests
+  // ============================================
+
+  describe('getExercisesWithCompleteImages', () => {
+    it('returns empty Set for empty input array', async () => {
+      const result = await getExercisesWithCompleteImages([]);
+
+      expect(result).toBeInstanceOf(Set);
+      expect(result.size).toBe(0);
+      expect(query).not.toHaveBeenCalled();
+    });
+
+    it('queries database with normalized exercise names', async () => {
+      vi.mocked(query).mockResolvedValueOnce({
+        rows: [
+          { normalized_name: 'push-up' },
+          { normalized_name: 'squats' },
+        ],
+        rowCount: 2,
+      });
+
+      await getExercisesWithCompleteImages(['Push Up', 'Squats', 'Burpees']);
+
+      expect(query).toHaveBeenCalledTimes(1);
+      expect(query).toHaveBeenCalledWith(
+        expect.stringContaining('SELECT DISTINCT e.normalized_name'),
+        [['push-up', 'squats', 'burpees']]
+      );
+    });
+
+    it('returns Set of normalized names with complete images', async () => {
+      vi.mocked(query).mockResolvedValueOnce({
+        rows: [
+          { normalized_name: 'push-up' },
+          { normalized_name: 'mountain-climbers' },
+        ],
+        rowCount: 2,
+      });
+
+      const result = await getExercisesWithCompleteImages([
+        'Push Up',
+        'Mountain Climbers',
+        'Burpees',
+      ]);
+
+      expect(result).toBeInstanceOf(Set);
+      expect(result.size).toBe(2);
+      expect(result.has('push-up')).toBe(true);
+      expect(result.has('mountain-climbers')).toBe(true);
+      expect(result.has('burpees')).toBe(false);
+    });
+
+    it('returns empty Set when no exercises have complete images', async () => {
+      vi.mocked(query).mockResolvedValueOnce({
+        rows: [],
+        rowCount: 0,
+      });
+
+      const result = await getExercisesWithCompleteImages(['Push Up', 'Squats']);
+
+      expect(result).toBeInstanceOf(Set);
+      expect(result.size).toBe(0);
+    });
+
+    it('handles duplicate exercise names', async () => {
+      vi.mocked(query).mockResolvedValueOnce({
+        rows: [{ normalized_name: 'push-up' }],
+        rowCount: 1,
+      });
+
+      const result = await getExercisesWithCompleteImages([
+        'Push Up',
+        'push up',
+        'PUSH UP',
+      ]);
+
+      // All should normalize to the same name
+      expect(result.has('push-up')).toBe(true);
+    });
+
+    it('handles exercises with special characters', async () => {
+      vi.mocked(query).mockResolvedValueOnce({
+        rows: [{ normalized_name: 'push-up-modified' }],
+        rowCount: 1,
+      });
+
+      const result = await getExercisesWithCompleteImages([
+        'Push Up (Modified)',
+      ]);
+
+      expect(result.has('push-up-modified')).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add server-side pre-flight check to determine which exercises have complete images before rendering
- Components now skip image loading entirely when images are not available in the database
- This prevents Next.js Image optimizer from returning 400 errors when image sources return non-200 responses

## Changes
- Add `getExercisesWithCompleteImages()` function to `src/lib/exercise-library.ts`
- Add `hasImages` prop to `ExerciseImages` and `ExerciseImageThumbnail` components
- Update workout detail page (`/workouts/[slug]`) to fetch image availability and pass to components
- Update workout player page (`/workouts/[slug]/play`) to fetch image availability and pass to GuidedRoutinePlayer
- Export `normalizeForUrl()` and add 255-character truncation to match server-side behavior

## Test plan
- [x] Unit tests for `getExercisesWithCompleteImages()` function
- [x] Unit tests for `normalizeForUrl()` function including 255-char truncation
- [x] Unit tests for `hasImages` prop on ExerciseImages and ExerciseImageThumbnail
- [x] All 1320 unit tests pass
- [x] Lint passes
- [x] Build succeeds
- [x] Manual browser testing: Verified no 400 errors on workout detail and player pages

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)