### PR TITLE
feat: implement ProcessPdfJob for PDF recipe extraction

### DIFF
--- a/sidequest.jobs.ts
+++ b/sidequest.jobs.ts
@@ -10,6 +10,4 @@
  */
 
 // Export all job classes here
-// Example: export { PdfProcessingJob } from "./src/jobs/PdfProcessingJob";
-
-export {};
+export { ProcessPdfJob } from "./src/jobs/ProcessPdfJob";

--- a/src/jobs/ExtractRecipeFromImageJob.ts
+++ b/src/jobs/ExtractRecipeFromImageJob.ts
@@ -1,0 +1,46 @@
+/**
+ * ExtractRecipeFromImageJob - Placeholder for child job
+ *
+ * This job extracts a recipe from a page image using the OpenAI Vision API.
+ * Full implementation is tracked in issue #228.
+ *
+ * This placeholder allows ProcessPdfJob to compile and be tested.
+ */
+import { Job } from "sidequest";
+
+export interface ExtractRecipeFromImageJobParams {
+  pdfJobId: number;
+  pageNumber: number;
+  imageBase64: string;
+  targetLocale: string;
+  targetRegion: string;
+  userId: number;
+}
+
+export interface ExtractRecipeFromImageJobResult {
+  pdfJobId: number;
+  pageNumber: number;
+  recipeSlug?: string;
+  recipeTitle?: string;
+  skipped?: boolean;
+}
+
+/**
+ * Job that extracts a recipe from a page image.
+ *
+ * Queue: recipe-extraction (concurrency: 3)
+ * Timeout: 120000ms (2 minutes)
+ * Max attempts: 2
+ *
+ * TODO: Implement in issue #228
+ */
+export class ExtractRecipeFromImageJob extends Job {
+  async run(
+    _params: ExtractRecipeFromImageJobParams
+  ): Promise<ExtractRecipeFromImageJobResult> {
+    // Placeholder implementation - will be replaced in issue #228
+    throw new Error(
+      "ExtractRecipeFromImageJob not yet implemented. See issue #228."
+    );
+  }
+}

--- a/src/jobs/ProcessPdfJob.ts
+++ b/src/jobs/ProcessPdfJob.ts
@@ -1,0 +1,124 @@
+/**
+ * ProcessPdfJob - Parent job for PDF recipe extraction
+ *
+ * Renders each page of a PDF to an image and spawns child jobs
+ * (ExtractRecipeFromImageJob) for recipe extraction per page.
+ */
+import { Job, Sidequest } from "sidequest";
+import { query } from "@/lib/db";
+import { getPdfInfo, renderPdfPageToImage } from "@/lib/pdf-utils";
+
+export interface ProcessPdfJobParams {
+  pdfJobId: number; // ID in pdf_extraction_jobs table
+  userId: number;
+  pdfBase64: string; // Base64-encoded PDF data
+  targetLocale: string; // e.g., 'en-US', 'de-DE'
+  targetRegion: string; // e.g., 'US', 'DE'
+}
+
+export interface ProcessPdfJobResult {
+  pdfJobId: number;
+  totalPages: number;
+  childJobsCreated: number;
+}
+
+/**
+ * Job that processes a PDF file by:
+ * 1. Parsing the PDF to get page count
+ * 2. Rendering each page to an image
+ * 3. Spawning child jobs (ExtractRecipeFromImageJob) for each page
+ *
+ * Queue: pdf-processing (concurrency: 1, memory-intensive)
+ * Timeout: 600000ms (10 minutes)
+ * Max attempts: 1 (don't retry entire PDF - each page is a separate job)
+ */
+export class ProcessPdfJob extends Job {
+  async run(params: ProcessPdfJobParams): Promise<ProcessPdfJobResult> {
+    const { pdfJobId, userId, pdfBase64, targetLocale, targetRegion } = params;
+
+    try {
+      // Update status to 'processing'
+      await query(
+        `UPDATE pdf_extraction_jobs
+         SET status = 'processing', started_at = NOW()
+         WHERE id = $1`,
+        [pdfJobId]
+      );
+
+      // Parse PDF and get page count
+      const pdfBuffer = Buffer.from(pdfBase64, "base64");
+      const pdfInfo = await getPdfInfo(pdfBuffer);
+
+      // Update total_pages in database
+      await query(
+        `UPDATE pdf_extraction_jobs
+         SET total_pages = $1
+         WHERE id = $2`,
+        [pdfInfo.pageCount, pdfJobId]
+      );
+
+      // Process each page: render to image and spawn child job
+      for (let pageNum = 1; pageNum <= pdfInfo.pageCount; pageNum++) {
+        // Render page to image (PNG at 200 DPI default)
+        const imageBuffer = await renderPdfPageToImage(pdfBuffer, pageNum);
+        const imageBase64 = imageBuffer.toString("base64");
+
+        // Enqueue ExtractRecipeFromImageJob
+        // Note: ExtractRecipeFromImageJob will be implemented in issue #228
+        // Using dynamic import to avoid TypeScript error until it exists
+        const { ExtractRecipeFromImageJob } = await import(
+          "./ExtractRecipeFromImageJob"
+        );
+
+        const childJobData = await Sidequest.build(ExtractRecipeFromImageJob)
+          .queue("recipe-extraction")
+          .timeout(120000) // 2 minutes per page
+          .maxAttempts(2)
+          .enqueue({
+            pdfJobId,
+            pageNumber: pageNum,
+            imageBase64,
+            targetLocale,
+            targetRegion,
+            userId,
+          });
+
+        // Insert child job record
+        await query(
+          `INSERT INTO pdf_page_extraction_jobs
+           (pdf_job_id, page_number, sidequest_job_id, status)
+           VALUES ($1, $2, $3, 'pending')`,
+          [pdfJobId, pageNum, String(childJobData.id)]
+        );
+      }
+
+      // Mark parent job as 'pages_queued'
+      await query(
+        `UPDATE pdf_extraction_jobs
+         SET status = 'pages_queued'
+         WHERE id = $1`,
+        [pdfJobId]
+      );
+
+      return {
+        pdfJobId,
+        totalPages: pdfInfo.pageCount,
+        childJobsCreated: pdfInfo.pageCount,
+      };
+    } catch (error) {
+      // Update job as failed
+      await query(
+        `UPDATE pdf_extraction_jobs
+         SET status = 'failed',
+             error_message = $1,
+             completed_at = NOW()
+         WHERE id = $2`,
+        [error instanceof Error ? error.message : "Unknown error", pdfJobId]
+      );
+
+      // Re-throw to mark SideQuest job as failed
+      // When an error is thrown, SideQuest marks the job as failed (no retry since max_attempts would be 1)
+      throw error instanceof Error ? error : new Error("Unknown error");
+    }
+  }
+}

--- a/src/jobs/__tests__/ProcessPdfJob.test.ts
+++ b/src/jobs/__tests__/ProcessPdfJob.test.ts
@@ -1,0 +1,405 @@
+/**
+ * Tests for ProcessPdfJob
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock modules before imports
+vi.mock("@/lib/db", () => ({
+  query: vi.fn(),
+}));
+
+vi.mock("@/lib/pdf-utils", () => ({
+  getPdfInfo: vi.fn(),
+  renderPdfPageToImage: vi.fn(),
+}));
+
+// Mock ExtractRecipeFromImageJob module
+vi.mock("../ExtractRecipeFromImageJob", () => ({
+  ExtractRecipeFromImageJob: class MockExtractRecipeFromImageJob {},
+}));
+
+// Mock sidequest module with factory that creates fresh mocks
+vi.mock("sidequest", () => {
+  const mockEnqueue = vi.fn();
+  const mockJobBuilder = {
+    queue: vi.fn().mockReturnThis(),
+    timeout: vi.fn().mockReturnThis(),
+    maxAttempts: vi.fn().mockReturnThis(),
+    enqueue: mockEnqueue,
+  };
+  return {
+    Job: class MockJob {},
+    Sidequest: {
+      build: vi.fn().mockReturnValue(mockJobBuilder),
+    },
+    __mockEnqueue: mockEnqueue,
+    __mockJobBuilder: mockJobBuilder,
+  };
+});
+
+import { query } from "@/lib/db";
+import { getPdfInfo, renderPdfPageToImage } from "@/lib/pdf-utils";
+import { Sidequest } from "sidequest";
+import {
+  ProcessPdfJob,
+  type ProcessPdfJobParams,
+} from "../ProcessPdfJob";
+
+// Get the mock functions from the mocked module
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const sidequestModule = await import("sidequest") as any;
+const mockEnqueue = sidequestModule.__mockEnqueue as ReturnType<typeof vi.fn>;
+const mockJobBuilder = sidequestModule.__mockJobBuilder as {
+  queue: ReturnType<typeof vi.fn>;
+  timeout: ReturnType<typeof vi.fn>;
+  maxAttempts: ReturnType<typeof vi.fn>;
+  enqueue: ReturnType<typeof vi.fn>;
+};
+
+describe("ProcessPdfJob", () => {
+  const mockQuery = query as ReturnType<typeof vi.fn>;
+  const mockGetPdfInfo = getPdfInfo as ReturnType<typeof vi.fn>;
+  const mockRenderPdfPageToImage = renderPdfPageToImage as ReturnType<
+    typeof vi.fn
+  >;
+
+  const defaultParams: ProcessPdfJobParams = {
+    pdfJobId: 123,
+    userId: 456,
+    pdfBase64: Buffer.from("fake pdf content").toString("base64"),
+    targetLocale: "en-US",
+    targetRegion: "US",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 1 });
+    mockEnqueue.mockResolvedValue({ id: "child-job-123" });
+    // Re-establish mockReturnValue for the builder chain after clearAllMocks
+    mockJobBuilder.queue.mockReturnThis();
+    mockJobBuilder.timeout.mockReturnThis();
+    mockJobBuilder.maxAttempts.mockReturnThis();
+    (Sidequest.build as ReturnType<typeof vi.fn>).mockReturnValue(mockJobBuilder);
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("successful processing", () => {
+    it("processes a PDF with multiple pages successfully", async () => {
+      mockGetPdfInfo.mockResolvedValue({ pageCount: 3 });
+      mockRenderPdfPageToImage.mockResolvedValue(
+        Buffer.from("fake image data")
+      );
+
+      const job = new ProcessPdfJob();
+      const result = await job.run(defaultParams);
+
+      expect(result).toEqual({
+        pdfJobId: 123,
+        totalPages: 3,
+        childJobsCreated: 3,
+      });
+    });
+
+    it("updates status to processing at job start", async () => {
+      mockGetPdfInfo.mockResolvedValue({ pageCount: 1 });
+      mockRenderPdfPageToImage.mockResolvedValue(Buffer.from("image"));
+
+      const job = new ProcessPdfJob();
+      await job.run(defaultParams);
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining("SET status = 'processing'"),
+        [123]
+      );
+    });
+
+    it("updates total_pages after parsing PDF", async () => {
+      mockGetPdfInfo.mockResolvedValue({ pageCount: 5 });
+      mockRenderPdfPageToImage.mockResolvedValue(Buffer.from("image"));
+
+      const job = new ProcessPdfJob();
+      await job.run(defaultParams);
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining("SET total_pages"),
+        [5, 123]
+      );
+    });
+
+    it("renders each page to an image", async () => {
+      mockGetPdfInfo.mockResolvedValue({ pageCount: 3 });
+      mockRenderPdfPageToImage.mockResolvedValue(Buffer.from("image"));
+
+      const job = new ProcessPdfJob();
+      await job.run(defaultParams);
+
+      expect(mockRenderPdfPageToImage).toHaveBeenCalledTimes(3);
+      expect(mockRenderPdfPageToImage).toHaveBeenNthCalledWith(
+        1,
+        expect.any(Buffer),
+        1
+      );
+      expect(mockRenderPdfPageToImage).toHaveBeenNthCalledWith(
+        2,
+        expect.any(Buffer),
+        2
+      );
+      expect(mockRenderPdfPageToImage).toHaveBeenNthCalledWith(
+        3,
+        expect.any(Buffer),
+        3
+      );
+    });
+
+    it("enqueues ExtractRecipeFromImageJob for each page", async () => {
+      mockGetPdfInfo.mockResolvedValue({ pageCount: 2 });
+      mockRenderPdfPageToImage.mockResolvedValue(Buffer.from("image data"));
+
+      const job = new ProcessPdfJob();
+      await job.run(defaultParams);
+
+      expect(Sidequest.build).toHaveBeenCalledTimes(2);
+      expect(mockJobBuilder.queue).toHaveBeenCalledWith("recipe-extraction");
+      expect(mockJobBuilder.timeout).toHaveBeenCalledWith(120000);
+      expect(mockJobBuilder.maxAttempts).toHaveBeenCalledWith(2);
+      expect(mockEnqueue).toHaveBeenCalledTimes(2);
+    });
+
+    it("passes correct parameters to child jobs", async () => {
+      mockGetPdfInfo.mockResolvedValue({ pageCount: 1 });
+      const imageBuffer = Buffer.from("test image");
+      mockRenderPdfPageToImage.mockResolvedValue(imageBuffer);
+
+      const job = new ProcessPdfJob();
+      await job.run(defaultParams);
+
+      expect(mockEnqueue).toHaveBeenCalledWith({
+        pdfJobId: 123,
+        pageNumber: 1,
+        imageBase64: imageBuffer.toString("base64"),
+        targetLocale: "en-US",
+        targetRegion: "US",
+        userId: 456,
+      });
+    });
+
+    it("inserts child job records into pdf_page_extraction_jobs", async () => {
+      mockGetPdfInfo.mockResolvedValue({ pageCount: 2 });
+      mockRenderPdfPageToImage.mockResolvedValue(Buffer.from("image"));
+      mockEnqueue.mockResolvedValueOnce({ id: "job-1" });
+      mockEnqueue.mockResolvedValueOnce({ id: "job-2" });
+
+      const job = new ProcessPdfJob();
+      await job.run(defaultParams);
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining("INSERT INTO pdf_page_extraction_jobs"),
+        [123, 1, "job-1"]
+      );
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining("INSERT INTO pdf_page_extraction_jobs"),
+        [123, 2, "job-2"]
+      );
+    });
+
+    it("marks job status as pages_queued when all pages are processed", async () => {
+      mockGetPdfInfo.mockResolvedValue({ pageCount: 2 });
+      mockRenderPdfPageToImage.mockResolvedValue(Buffer.from("image"));
+
+      const job = new ProcessPdfJob();
+      await job.run(defaultParams);
+
+      // Last status update should be 'pages_queued'
+      const statusCalls = mockQuery.mock.calls.filter(
+        (call) =>
+          typeof call[0] === "string" &&
+          call[0].includes("status = 'pages_queued'")
+      );
+      expect(statusCalls.length).toBe(1);
+    });
+  });
+
+  describe("empty PDF handling", () => {
+    it("handles PDF with 0 pages (moves directly to pages_queued)", async () => {
+      mockGetPdfInfo.mockResolvedValue({ pageCount: 0 });
+
+      const job = new ProcessPdfJob();
+      const result = await job.run(defaultParams);
+
+      expect(result).toEqual({
+        pdfJobId: 123,
+        totalPages: 0,
+        childJobsCreated: 0,
+      });
+
+      expect(mockRenderPdfPageToImage).not.toHaveBeenCalled();
+      expect(mockEnqueue).not.toHaveBeenCalled();
+
+      // Should still update status to pages_queued
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining("status = 'pages_queued'"),
+        [123]
+      );
+    });
+  });
+
+  describe("error handling", () => {
+    it("marks job as failed and throws when PDF parsing fails", async () => {
+      mockGetPdfInfo.mockRejectedValue(new Error("Invalid PDF format"));
+
+      const job = new ProcessPdfJob();
+      await expect(job.run(defaultParams)).rejects.toThrow("Invalid PDF format");
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining("status = 'failed'"),
+        ["Invalid PDF format", 123]
+      );
+    });
+
+    it("marks job as failed and throws when PDF has too many pages", async () => {
+      mockGetPdfInfo.mockRejectedValue(
+        new Error("PDF has too many pages (51). Maximum: 50")
+      );
+
+      const job = new ProcessPdfJob();
+      await expect(job.run(defaultParams)).rejects.toThrow(
+        "PDF has too many pages (51). Maximum: 50"
+      );
+    });
+
+    it("marks job as failed and throws when page rendering fails", async () => {
+      mockGetPdfInfo.mockResolvedValue({ pageCount: 3 });
+      mockRenderPdfPageToImage
+        .mockResolvedValueOnce(Buffer.from("image"))
+        .mockRejectedValueOnce(new Error("Render failed on page 2"));
+
+      const job = new ProcessPdfJob();
+      await expect(job.run(defaultParams)).rejects.toThrow(
+        "Render failed on page 2"
+      );
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining("status = 'failed'"),
+        ["Render failed on page 2", 123]
+      );
+    });
+
+    it("marks job as failed and throws when child job enqueueing fails", async () => {
+      mockGetPdfInfo.mockResolvedValue({ pageCount: 2 });
+      mockRenderPdfPageToImage.mockResolvedValue(Buffer.from("image"));
+      mockEnqueue.mockRejectedValue(new Error("Queue unavailable"));
+
+      const job = new ProcessPdfJob();
+      await expect(job.run(defaultParams)).rejects.toThrow("Queue unavailable");
+    });
+
+    it("handles non-Error exceptions by wrapping in Error", async () => {
+      mockGetPdfInfo.mockRejectedValue("String error");
+
+      const job = new ProcessPdfJob();
+      await expect(job.run(defaultParams)).rejects.toThrow("Unknown error");
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining("status = 'failed'"),
+        ["Unknown error", 123]
+      );
+    });
+
+    it("sets completed_at timestamp when job fails", async () => {
+      mockGetPdfInfo.mockRejectedValue(new Error("Test error"));
+
+      const job = new ProcessPdfJob();
+      await expect(job.run(defaultParams)).rejects.toThrow("Test error");
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining("completed_at = NOW()"),
+        expect.any(Array)
+      );
+    });
+  });
+
+  describe("database interactions", () => {
+    it("calls database queries in correct order", async () => {
+      mockGetPdfInfo.mockResolvedValue({ pageCount: 1 });
+      mockRenderPdfPageToImage.mockResolvedValue(Buffer.from("image"));
+
+      const job = new ProcessPdfJob();
+      await job.run(defaultParams);
+
+      const calls = mockQuery.mock.calls.map((call) => {
+        const sql = call[0] as string;
+        if (sql.includes("status = 'processing'")) return "set_processing";
+        if (sql.includes("total_pages")) return "set_total_pages";
+        if (sql.includes("INSERT INTO pdf_page_extraction_jobs"))
+          return "insert_page_job";
+        if (sql.includes("status = 'pages_queued'")) return "set_pages_queued";
+        return "unknown";
+      });
+
+      expect(calls).toEqual([
+        "set_processing",
+        "set_total_pages",
+        "insert_page_job",
+        "set_pages_queued",
+      ]);
+    });
+  });
+
+  describe("base64 encoding", () => {
+    it("correctly decodes base64 PDF data", async () => {
+      const originalContent = "PDF binary content here";
+      const base64Content = Buffer.from(originalContent).toString("base64");
+
+      mockGetPdfInfo.mockResolvedValue({ pageCount: 1 });
+      mockRenderPdfPageToImage.mockResolvedValue(Buffer.from("image"));
+
+      const job = new ProcessPdfJob();
+      await job.run({
+        ...defaultParams,
+        pdfBase64: base64Content,
+      });
+
+      // Check that getPdfInfo was called with a Buffer containing the original content
+      const pdfBuffer = mockGetPdfInfo.mock.calls[0][0] as Buffer;
+      expect(pdfBuffer.toString()).toBe(originalContent);
+    });
+
+    it("correctly encodes rendered images to base64 for child jobs", async () => {
+      const imageContent = "PNG image binary data";
+      mockGetPdfInfo.mockResolvedValue({ pageCount: 1 });
+      mockRenderPdfPageToImage.mockResolvedValue(Buffer.from(imageContent));
+
+      const job = new ProcessPdfJob();
+      await job.run(defaultParams);
+
+      const childJobParams = mockEnqueue.mock.calls[0][0];
+      expect(childJobParams.imageBase64).toBe(
+        Buffer.from(imageContent).toString("base64")
+      );
+    });
+  });
+
+  describe("localization parameters", () => {
+    it("passes targetLocale and targetRegion to child jobs", async () => {
+      mockGetPdfInfo.mockResolvedValue({ pageCount: 1 });
+      mockRenderPdfPageToImage.mockResolvedValue(Buffer.from("image"));
+
+      const job = new ProcessPdfJob();
+      await job.run({
+        ...defaultParams,
+        targetLocale: "de-DE",
+        targetRegion: "DE",
+      });
+
+      expect(mockEnqueue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          targetLocale: "de-DE",
+          targetRegion: "DE",
+        })
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implement `ProcessPdfJob` class for processing PDF files in the recipe extraction pipeline
- Add placeholder `ExtractRecipeFromImageJob` for child job (to be implemented in #228)
- Export job classes from `sidequest.jobs.ts` for SideQuest job resolution
- Add comprehensive unit tests (19 test cases)

## Implementation Details

The `ProcessPdfJob` class:
1. Updates job status to 'processing' in database
2. Parses PDF to get page count using `getPdfInfo`
3. Renders each page to PNG image using `renderPdfPageToImage`
4. Spawns `ExtractRecipeFromImageJob` child jobs via SideQuest
5. Tracks child jobs in `pdf_page_extraction_jobs` table
6. Updates final status to 'pages_queued'

Error handling updates database with failure status and error message, then re-throws to mark SideQuest job as failed.

## Test plan
- [x] Unit tests pass (19 new tests covering all scenarios)
- [x] Lint passes
- [x] Build passes
- [x] All 1382 existing tests still pass

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)