### PR TITLE
fix: install poppler-utils in Docker image for PDF rendering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ RUN npm run build
 FROM base AS runner
 ENV NODE_ENV=production
 
+# Install poppler-utils for PDF rendering (pdftoppm command)
+RUN apk add --no-cache poppler-utils
+
 # Copy standalone build
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static


### PR DESCRIPTION
## Summary
- Adds `poppler-utils` package installation to the Docker runner stage
- Fixes "spawn pdftoppm ENOENT" error when rendering PDF pages to images

## Problem
The `ProcessPdfJob` at `src/jobs/ProcessPdfJob.ts:63` calls `renderPdfPageToImage()` which executes the `pdftoppm` command from `poppler-utils` at `src/lib/pdf-utils.ts:239`. This binary was not installed in the production Docker container.

## Solution
Added `RUN apk add --no-cache poppler-utils` to the runner stage of the Dockerfile.

## Test plan
- [x] ESLint check passed
- [x] Next.js production build succeeded  
- [x] All 1390 unit tests passed
- [ ] Docker build succeeds in CI
- [ ] PDF extraction works in production after deployment

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)