### PR TITLE
feat: add GET polling endpoint for PDF extraction job status

### DIFF
--- a/src/app/api/recipes/extract-from-pdf/[jobId]/__tests__/route.test.ts
+++ b/src/app/api/recipes/extract-from-pdf/[jobId]/__tests__/route.test.ts
@@ -1,0 +1,479 @@
+/**
+ * Tests for GET /api/recipes/extract-from-pdf/[jobId]
+ * Polling endpoint for PDF extraction job status
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET } from '../route';
+
+// Mock auth
+vi.mock('@/lib/auth', () => ({
+  auth: vi.fn(),
+}));
+
+// Mock database
+vi.mock('@/lib/db', () => ({
+  query: vi.fn(),
+}));
+
+import { auth } from '@/lib/auth';
+import { query } from '@/lib/db';
+
+// Helper to create mock params
+function createMockParams(jobId: string): { params: Promise<{ jobId: string }> } {
+  return {
+    params: Promise.resolve({ jobId }),
+  };
+}
+
+// Mock job row factory
+function createMockJobRow(overrides: Partial<{
+  id: number;
+  user_id: number;
+  total_pages: number | null;
+  pages_processed: number;
+  recipes_extracted: number;
+  status: string;
+  error_message: string | null;
+  created_at: Date;
+  completed_at: Date | null;
+}> = {}) {
+  return {
+    id: 42,
+    user_id: 123,
+    total_pages: 10,
+    pages_processed: 5,
+    recipes_extracted: 3,
+    status: 'pages_queued',
+    error_message: null,
+    created_at: new Date('2026-01-20T10:30:00.000Z'),
+    completed_at: null,
+    ...overrides,
+  };
+}
+
+describe('GET /api/recipes/extract-from-pdf/[jobId]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default authenticated user
+    vi.mocked(auth).mockResolvedValue({
+      user: { id: '123' },
+    } as never);
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when not authenticated', async () => {
+      vi.mocked(auth).mockResolvedValueOnce(null);
+
+      const response = await GET(new Request('http://localhost'), createMockParams('42'));
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error).toBe('Unauthorized');
+    });
+
+    it('returns 401 when session has no user ID', async () => {
+      vi.mocked(auth).mockResolvedValueOnce({ user: {} } as never);
+
+      const response = await GET(new Request('http://localhost'), createMockParams('42'));
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error).toBe('Unauthorized');
+    });
+  });
+
+  describe('input validation', () => {
+    it('returns 400 for non-numeric job ID', async () => {
+      const response = await GET(new Request('http://localhost'), createMockParams('invalid'));
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe('Invalid job ID');
+    });
+
+    it('returns 400 for empty job ID', async () => {
+      const response = await GET(new Request('http://localhost'), createMockParams(''));
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe('Invalid job ID');
+    });
+  });
+
+  describe('authorization', () => {
+    it('returns 404 when job not found', async () => {
+      vi.mocked(query).mockResolvedValueOnce({ rows: [] });
+
+      const response = await GET(new Request('http://localhost'), createMockParams('999'));
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error).toBe('Job not found');
+    });
+
+    it('returns 404 when job belongs to different user (prevents enumeration)', async () => {
+      // Job exists but user_id doesn't match - query returns empty
+      vi.mocked(query).mockResolvedValueOnce({ rows: [] });
+
+      const response = await GET(new Request('http://localhost'), createMockParams('42'));
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error).toBe('Job not found');
+
+      // Verify query includes user_id check
+      expect(query).toHaveBeenCalledWith(
+        expect.stringContaining('user_id = $2'),
+        [42, 123]
+      );
+    });
+  });
+
+  describe('job status - pending', () => {
+    it('returns correct status for pending job', async () => {
+      vi.mocked(query)
+        .mockResolvedValueOnce({
+          rows: [createMockJobRow({ status: 'pending', pages_processed: 0, recipes_extracted: 0 })],
+        })
+        .mockResolvedValueOnce({ rows: [] }) // no recipes
+        .mockResolvedValueOnce({ rows: [] }); // no skipped pages
+
+      const response = await GET(new Request('http://localhost'), createMockParams('42'));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.status).toBe('pending');
+      expect(data.progress.currentPage).toBe(0);
+      expect(data.progress.recipesExtracted).toBe(0);
+      expect(data.recipes).toEqual([]);
+      expect(data.skippedPages).toEqual([]);
+    });
+  });
+
+  describe('job status - processing', () => {
+    it('returns correct status for processing job', async () => {
+      vi.mocked(query)
+        .mockResolvedValueOnce({
+          rows: [createMockJobRow({ status: 'processing', pages_processed: 2, recipes_extracted: 1 })],
+        })
+        .mockResolvedValueOnce({
+          rows: [{ recipe_slug: 'chocolate-cake', recipe_title: 'Chocolate Cake', page_number: 1 }],
+        })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const response = await GET(new Request('http://localhost'), createMockParams('42'));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.status).toBe('processing');
+      expect(data.progress.currentPage).toBe(2);
+      expect(data.progress.recipesExtracted).toBe(1);
+      expect(data.recipes).toHaveLength(1);
+      expect(data.recipes[0]).toEqual({
+        slug: 'chocolate-cake',
+        title: 'Chocolate Cake',
+        pageNumber: 1,
+      });
+    });
+  });
+
+  describe('job status - pages_queued with partial results', () => {
+    it('returns extracted recipes and skipped pages', async () => {
+      vi.mocked(query)
+        .mockResolvedValueOnce({
+          rows: [createMockJobRow({
+            status: 'pages_queued',
+            total_pages: 10,
+            pages_processed: 5,
+            recipes_extracted: 3,
+          })],
+        })
+        .mockResolvedValueOnce({
+          rows: [
+            { recipe_slug: 'chocolate-cake', recipe_title: 'Chocolate Cake', page_number: 1 },
+            { recipe_slug: 'vanilla-ice-cream', recipe_title: 'Vanilla Ice Cream', page_number: 3 },
+            { recipe_slug: 'banana-bread', recipe_title: 'Banana Bread', page_number: 4 },
+          ],
+        })
+        .mockResolvedValueOnce({
+          rows: [{ page_number: 2 }],
+        });
+
+      const response = await GET(new Request('http://localhost'), createMockParams('42'));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.status).toBe('pages_queued');
+      expect(data.progress).toEqual({
+        currentPage: 5,
+        totalPages: 10,
+        recipesExtracted: 3,
+      });
+      expect(data.recipes).toHaveLength(3);
+      expect(data.recipes[0]).toEqual({ slug: 'chocolate-cake', title: 'Chocolate Cake', pageNumber: 1 });
+      expect(data.recipes[1]).toEqual({ slug: 'vanilla-ice-cream', title: 'Vanilla Ice Cream', pageNumber: 3 });
+      expect(data.recipes[2]).toEqual({ slug: 'banana-bread', title: 'Banana Bread', pageNumber: 4 });
+      expect(data.skippedPages).toEqual([2]);
+    });
+  });
+
+  describe('job status - completed', () => {
+    it('returns full results for completed job', async () => {
+      const completedAt = new Date('2026-01-20T11:00:00.000Z');
+      vi.mocked(query)
+        .mockResolvedValueOnce({
+          rows: [createMockJobRow({
+            status: 'completed',
+            total_pages: 3,
+            pages_processed: 3,
+            recipes_extracted: 2,
+            completed_at: completedAt,
+          })],
+        })
+        .mockResolvedValueOnce({
+          rows: [
+            { recipe_slug: 'recipe-1', recipe_title: 'Recipe 1', page_number: 1 },
+            { recipe_slug: 'recipe-2', recipe_title: 'Recipe 2', page_number: 3 },
+          ],
+        })
+        .mockResolvedValueOnce({
+          rows: [{ page_number: 2 }],
+        });
+
+      const response = await GET(new Request('http://localhost'), createMockParams('42'));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.status).toBe('completed');
+      expect(data.completedAt).toBe('2026-01-20T11:00:00.000Z');
+      expect(data.progress.currentPage).toBe(3);
+      expect(data.progress.totalPages).toBe(3);
+      expect(data.recipes).toHaveLength(2);
+      expect(data.skippedPages).toEqual([2]);
+    });
+  });
+
+  describe('job status - failed', () => {
+    it('returns error message for failed job', async () => {
+      vi.mocked(query)
+        .mockResolvedValueOnce({
+          rows: [createMockJobRow({
+            status: 'failed',
+            error_message: 'PDF parsing failed: corrupted file',
+            pages_processed: 0,
+            recipes_extracted: 0,
+          })],
+        })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const response = await GET(new Request('http://localhost'), createMockParams('42'));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.status).toBe('failed');
+      expect(data.error).toBe('PDF parsing failed: corrupted file');
+      expect(data.recipes).toEqual([]);
+    });
+  });
+
+  describe('job status - cancelled', () => {
+    it('returns cancelled status', async () => {
+      vi.mocked(query)
+        .mockResolvedValueOnce({
+          rows: [createMockJobRow({ status: 'cancelled' })],
+        })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const response = await GET(new Request('http://localhost'), createMockParams('42'));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.status).toBe('cancelled');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns empty arrays when no recipes extracted yet', async () => {
+      vi.mocked(query)
+        .mockResolvedValueOnce({
+          rows: [createMockJobRow({ status: 'processing', recipes_extracted: 0 })],
+        })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const response = await GET(new Request('http://localhost'), createMockParams('42'));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.recipes).toEqual([]);
+      expect(data.skippedPages).toEqual([]);
+    });
+
+    it('handles null total_pages by returning 0', async () => {
+      vi.mocked(query)
+        .mockResolvedValueOnce({
+          rows: [createMockJobRow({ total_pages: null })],
+        })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const response = await GET(new Request('http://localhost'), createMockParams('42'));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.progress.totalPages).toBe(0);
+    });
+
+    it('handles multiple skipped pages', async () => {
+      vi.mocked(query)
+        .mockResolvedValueOnce({
+          rows: [createMockJobRow({ status: 'completed' })],
+        })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({
+          rows: [{ page_number: 2 }, { page_number: 4 }, { page_number: 6 }],
+        });
+
+      const response = await GET(new Request('http://localhost'), createMockParams('42'));
+      const data = await response.json();
+
+      expect(data.skippedPages).toEqual([2, 4, 6]);
+    });
+  });
+
+  describe('response format', () => {
+    it('returns correct response structure', async () => {
+      vi.mocked(query)
+        .mockResolvedValueOnce({
+          rows: [createMockJobRow()],
+        })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const response = await GET(new Request('http://localhost'), createMockParams('42'));
+      const data = await response.json();
+
+      expect(data).toHaveProperty('jobId');
+      expect(data).toHaveProperty('status');
+      expect(data).toHaveProperty('progress');
+      expect(data.progress).toHaveProperty('currentPage');
+      expect(data.progress).toHaveProperty('totalPages');
+      expect(data.progress).toHaveProperty('recipesExtracted');
+      expect(data).toHaveProperty('recipes');
+      expect(data).toHaveProperty('skippedPages');
+      expect(data).toHaveProperty('error');
+      expect(data).toHaveProperty('createdAt');
+      expect(data).toHaveProperty('completedAt');
+    });
+
+    it('formats dates as ISO strings', async () => {
+      const createdAt = new Date('2026-01-20T10:30:00.000Z');
+      const completedAt = new Date('2026-01-20T11:00:00.000Z');
+
+      vi.mocked(query)
+        .mockResolvedValueOnce({
+          rows: [createMockJobRow({ created_at: createdAt, completed_at: completedAt })],
+        })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const response = await GET(new Request('http://localhost'), createMockParams('42'));
+      const data = await response.json();
+
+      expect(data.createdAt).toBe('2026-01-20T10:30:00.000Z');
+      expect(data.completedAt).toBe('2026-01-20T11:00:00.000Z');
+    });
+
+    it('returns null for completedAt when not set', async () => {
+      vi.mocked(query)
+        .mockResolvedValueOnce({
+          rows: [createMockJobRow({ completed_at: null })],
+        })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const response = await GET(new Request('http://localhost'), createMockParams('42'));
+      const data = await response.json();
+
+      expect(data.completedAt).toBeNull();
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 500 on database error', async () => {
+      vi.mocked(query).mockRejectedValueOnce(new Error('Database connection failed'));
+
+      const response = await GET(new Request('http://localhost'), createMockParams('42'));
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.error).toBe('Failed to fetch job status');
+    });
+
+    it('returns 500 when recipes query fails', async () => {
+      vi.mocked(query)
+        .mockResolvedValueOnce({ rows: [createMockJobRow()] })
+        .mockRejectedValueOnce(new Error('Query failed'));
+
+      const response = await GET(new Request('http://localhost'), createMockParams('42'));
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.error).toBe('Failed to fetch job status');
+    });
+  });
+
+  describe('query optimization', () => {
+    it('runs recipes and skipped pages queries in parallel', async () => {
+      const queryStart: number[] = [];
+      const queryEnd: number[] = [];
+
+      vi.mocked(query)
+        .mockResolvedValueOnce({ rows: [createMockJobRow()] })
+        .mockImplementationOnce(async () => {
+          queryStart.push(Date.now());
+          await new Promise(resolve => setTimeout(resolve, 10));
+          queryEnd.push(Date.now());
+          return { rows: [] };
+        })
+        .mockImplementationOnce(async () => {
+          queryStart.push(Date.now());
+          await new Promise(resolve => setTimeout(resolve, 10));
+          queryEnd.push(Date.now());
+          return { rows: [] };
+        });
+
+      await GET(new Request('http://localhost'), createMockParams('42'));
+
+      // Both parallel queries should start at nearly the same time
+      expect(Math.abs(queryStart[0] - queryStart[1])).toBeLessThan(5);
+    });
+
+    it('only queries for completed and skipped statuses', async () => {
+      vi.mocked(query)
+        .mockResolvedValueOnce({ rows: [createMockJobRow()] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] });
+
+      await GET(new Request('http://localhost'), createMockParams('42'));
+
+      // Second call should query for completed recipes
+      expect(query).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining("status = 'completed'"),
+        expect.any(Array)
+      );
+
+      // Third call should query for skipped pages
+      expect(query).toHaveBeenNthCalledWith(
+        3,
+        expect.stringContaining("status = 'skipped'"),
+        expect.any(Array)
+      );
+    });
+  });
+});

--- a/src/app/api/recipes/extract-from-pdf/[jobId]/route.ts
+++ b/src/app/api/recipes/extract-from-pdf/[jobId]/route.ts
@@ -1,0 +1,143 @@
+/**
+ * GET /api/recipes/extract-from-pdf/[jobId]
+ * Poll PDF extraction job status and progress
+ *
+ * Response:
+ *   - Success: HTTP 200 { jobId, status, progress, recipes, skippedPages, error, createdAt, completedAt }
+ *   - Error: { error: string }
+ */
+
+import { auth } from '@/lib/auth';
+import { query } from '@/lib/db';
+
+export const runtime = 'nodejs';
+
+type RouteParams = { params: Promise<{ jobId: string }> };
+
+// Type definitions
+interface PdfExtractionJobRow {
+  id: number;
+  user_id: number;
+  total_pages: number | null;
+  pages_processed: number;
+  recipes_extracted: number;
+  status: 'pending' | 'processing' | 'pages_queued' | 'completed' | 'failed' | 'cancelled';
+  error_message: string | null;
+  created_at: Date;
+  completed_at: Date | null;
+}
+
+interface PageJobRow {
+  recipe_slug: string;
+  recipe_title: string;
+  page_number: number;
+}
+
+interface SkippedPageRow {
+  page_number: number;
+}
+
+interface ExtractedRecipe {
+  slug: string;
+  title: string;
+  pageNumber: number;
+}
+
+interface JobStatusResponse {
+  jobId: number;
+  status: string;
+  progress: {
+    currentPage: number;
+    totalPages: number;
+    recipesExtracted: number;
+  };
+  recipes: ExtractedRecipe[];
+  skippedPages: number[];
+  error: string | null;
+  createdAt: string;
+  completedAt: string | null;
+}
+
+export async function GET(request: Request, { params }: RouteParams) {
+  // 1. Authenticate user
+  const session = await auth();
+  if (!session?.user?.id) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const { jobId } = await params;
+    const jobIdNum = parseInt(jobId, 10);
+    const userIdNum = parseInt(session.user.id, 10);
+
+    // Validate jobId is a number
+    if (isNaN(jobIdNum)) {
+      return Response.json({ error: 'Invalid job ID' }, { status: 400 });
+    }
+
+    // 2. Query parent job with ownership check
+    const jobResult = await query(
+      `SELECT id, user_id, total_pages, pages_processed, recipes_extracted,
+              status, error_message, created_at, completed_at
+       FROM pdf_extraction_jobs
+       WHERE id = $1 AND user_id = $2`,
+      [jobIdNum, userIdNum]
+    );
+
+    if (jobResult.rows.length === 0) {
+      return Response.json({ error: 'Job not found' }, { status: 404 });
+    }
+
+    const job = jobResult.rows[0] as PdfExtractionJobRow;
+
+    // 3. Query completed recipes and skipped pages in parallel
+    const [recipesResult, skippedResult] = await Promise.all([
+      query(
+        `SELECT recipe_slug, recipe_title, page_number
+         FROM pdf_page_extraction_jobs
+         WHERE pdf_job_id = $1 AND status = 'completed'
+         ORDER BY page_number ASC`,
+        [jobIdNum]
+      ),
+      query(
+        `SELECT page_number
+         FROM pdf_page_extraction_jobs
+         WHERE pdf_job_id = $1 AND status = 'skipped'
+         ORDER BY page_number ASC`,
+        [jobIdNum]
+      ),
+    ]);
+
+    // 4. Build response
+    const recipes: ExtractedRecipe[] = (recipesResult.rows as PageJobRow[]).map((row) => ({
+      slug: row.recipe_slug,
+      title: row.recipe_title,
+      pageNumber: row.page_number,
+    }));
+
+    const skippedPages: number[] = (skippedResult.rows as SkippedPageRow[]).map((row) => row.page_number);
+
+    const response: JobStatusResponse = {
+      jobId: job.id,
+      status: job.status,
+      progress: {
+        currentPage: job.pages_processed,
+        totalPages: job.total_pages ?? 0,
+        recipesExtracted: job.recipes_extracted,
+      },
+      recipes,
+      skippedPages,
+      error: job.error_message,
+      createdAt: job.created_at.toISOString(),
+      completedAt: job.completed_at?.toISOString() ?? null,
+    };
+
+    return Response.json(response);
+  } catch (error) {
+    console.error('Error fetching job status:', error);
+    return Response.json(
+      { error: 'Failed to fetch job status' },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Implements issue #230: Add GET `/api/recipes/extract-from-pdf/[jobId]` polling endpoint for PDF extraction job status.

- GET endpoint to poll PDF extraction job progress and results
- Returns job status, progress (currentPage/totalPages/recipesExtracted), extracted recipes, skipped pages
- User-scoped security (users can only access their own jobs)
- Parallel database queries for optimal performance
- Comprehensive unit tests (22 tests)

## Test plan

- [x] Unit tests pass (22 new tests)
- [x] Lint check passes
- [x] Production build succeeds
- [x] Manual browser testing verified all response scenarios:
  - 401 for unauthenticated requests
  - 400 for invalid job ID
  - 404 for non-existent jobs
  - 404 for other users' jobs (security)
  - 200 with correct response format

## Response Format

```json
{
  "jobId": 1,
  "status": "pages_queued",
  "progress": {
    "currentPage": 3,
    "totalPages": 5,
    "recipesExtracted": 2
  },
  "recipes": [
    { "slug": "chocolate-cake", "title": "Chocolate Cake", "pageNumber": 1 }
  ],
  "skippedPages": [2],
  "error": null,
  "createdAt": "2026-01-20T10:30:00.000Z",
  "completedAt": null
}
```

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)