### PR TITLE
fix: add cache-busting build argument to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN npm ci
 
 FROM base AS builder
 ENV NODE_ENV=production
+# Cache bust argument - change this value to invalidate Docker layer cache
+ARG CACHE_BUST=1
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN npm run build


### PR DESCRIPTION
## Summary
- Add `ARG CACHE_BUST=1` to Docker builder stage to enable cache invalidation
- Fixes Railway serving stale cached builds that don't include new routes
- Addresses production issue where `/api/recipes/extract-from-pdf/[jobId]` was returning HTML 404

## Context
PR #244 added a new GET endpoint for polling PDF extraction job status, but Railway was serving a cached Docker build from before the merge. This change provides a mechanism to invalidate the build cache.

## Test plan
- [x] Verify `npm run lint` passes
- [x] Verify `npm run build` succeeds and includes the route
- [x] Test endpoint locally returns JSON responses (401/400) instead of HTML 404
- [ ] After merge, verify `railway up` triggers fresh build
- [ ] Verify production endpoint returns JSON responses

## Verification commands
```bash
# Test endpoint should return JSON, not HTML 404
curl -s -o /dev/null -w "%{http_code}" https://fitstreak.app/api/recipes/extract-from-pdf/test-id
# Expected: 401 (unauthorized) - proves route exists
```

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)