### PR TITLE
feat: add DELETE endpoint to cancel PDF extraction jobs

### DIFF
--- a/src/app/api/recipes/extract-from-pdf/[jobId]/__tests__/route.test.ts
+++ b/src/app/api/recipes/extract-from-pdf/[jobId]/__tests__/route.test.ts
@@ -608,10 +608,10 @@ describe('DELETE /api/recipes/extract-from-pdf/[jobId]', () => {
         [42]
       );
 
-      // Verify child jobs update
+      // Verify child jobs update (uses 'skipped' per DB constraint on pdf_page_extraction_jobs)
       expect(query).toHaveBeenNthCalledWith(
         3,
-        expect.stringContaining("pdf_page_extraction_jobs"),
+        expect.stringContaining("SET status = 'skipped'"),
         [42]
       );
     });

--- a/src/app/api/recipes/extract-from-pdf/[jobId]/route.ts
+++ b/src/app/api/recipes/extract-from-pdf/[jobId]/route.ts
@@ -196,10 +196,10 @@ export async function DELETE(request: Request, { params }: RouteParams) {
       [jobIdNum]
     );
 
-    // 5. Also cancel any pending child page jobs
+    // 5. Also skip any pending child page jobs (use 'skipped' per DB constraint)
     await query(
       `UPDATE pdf_page_extraction_jobs
-       SET status = 'cancelled', completed_at = NOW()
+       SET status = 'skipped', completed_at = NOW()
        WHERE pdf_job_id = $1 AND status = 'pending'`,
       [jobIdNum]
     );

--- a/src/jobs/ExtractRecipeFromImageJob.ts
+++ b/src/jobs/ExtractRecipeFromImageJob.ts
@@ -48,10 +48,10 @@ export class ExtractRecipeFromImageJob extends Job {
     );
 
     if (parentJob.rows.length === 0 || parentJob.rows[0].status === 'cancelled') {
-      // Mark this page job as cancelled
+      // Mark this page job as skipped (use 'skipped' per DB constraint)
       await query(
         `UPDATE pdf_page_extraction_jobs
-         SET status = 'cancelled', completed_at = NOW()
+         SET status = 'skipped', completed_at = NOW()
          WHERE pdf_job_id = $1 AND page_number = $2`,
         [pdfJobId, pageNumber]
       );

--- a/src/jobs/__tests__/ExtractRecipeFromImageJob.test.ts
+++ b/src/jobs/__tests__/ExtractRecipeFromImageJob.test.ts
@@ -39,7 +39,7 @@ describe('ExtractRecipeFromImageJob', () => {
   });
 
   describe('cancellation check', () => {
-    it('marks page as cancelled when parent job is cancelled', async () => {
+    it('marks page as skipped when parent job is cancelled', async () => {
       vi.mocked(query)
         .mockResolvedValueOnce({ rows: [{ status: 'cancelled' }] })
         .mockResolvedValueOnce({ rows: [] });
@@ -51,15 +51,15 @@ describe('ExtractRecipeFromImageJob', () => {
       expect(result.pdfJobId).toBe(1);
       expect(result.pageNumber).toBe(1);
 
-      // Verify page job update query
+      // Verify page job update query (uses 'skipped' per DB constraint on pdf_page_extraction_jobs)
       expect(query).toHaveBeenNthCalledWith(
         2,
-        expect.stringContaining("status = 'cancelled'"),
+        expect.stringContaining("status = 'skipped'"),
         [1, 1]
       );
     });
 
-    it('marks page as cancelled when parent job not found', async () => {
+    it('marks page as skipped when parent job not found', async () => {
       vi.mocked(query)
         .mockResolvedValueOnce({ rows: [] })
         .mockResolvedValueOnce({ rows: [] });


### PR DESCRIPTION
## Summary
- Add DELETE /api/recipes/extract-from-pdf/[jobId] endpoint to cancel PDF extraction jobs
- Implement ownership verification (users can only cancel their own jobs)
- Return 400 error for jobs that are already finished (completed, failed, cancelled)
- Cascade cancellation to pending child page jobs
- Add cancellation check in job handlers to skip processing if parent job is cancelled

## Test plan
- [x] Unit tests for DELETE endpoint (13 tests covering auth, authorization, status checks, error handling)
- [x] Unit tests for ExtractRecipeFromImageJob cancellation check (5 tests)
- [x] Lint check passes
- [x] Build succeeds
- [x] All 1430 unit tests pass

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)