### PR TITLE
fix: use dynamic RAILWAY_GIT_COMMIT_SHA for Docker cache busting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,12 @@ RUN npm ci
 
 FROM base AS builder
 ENV NODE_ENV=production
-# Cache bust argument - change this value to invalidate Docker layer cache
-ARG CACHE_BUST=1
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-RUN npm run build
+# Railway provides RAILWAY_GIT_COMMIT_SHA automatically on each deploy
+# This ARG declaration makes Docker aware of it for cache invalidation
+ARG RAILWAY_GIT_COMMIT_SHA=""
+RUN echo "Building commit: ${RAILWAY_GIT_COMMIT_SHA:-local}" && npm run build
 
 FROM base AS runner
 ENV NODE_ENV=production

--- a/railway.toml
+++ b/railway.toml
@@ -3,6 +3,10 @@ name = "habits"
 
 [build]
 builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile"
+
+[build.args]
+RAILWAY_GIT_COMMIT_SHA = "${{RAILWAY_GIT_COMMIT_SHA}}"
 
 [deploy]
 healthcheckPath = "/health"


### PR DESCRIPTION
## Summary

- Updated `Dockerfile` to use `RAILWAY_GIT_COMMIT_SHA` instead of static `CACHE_BUST=1` for cache invalidation
- Updated `railway.toml` to pass the commit SHA as a Docker build argument

The previous `CACHE_BUST=1` argument was ineffective because Docker only invalidates cache when ARG values change. Since the value was hardcoded to `1`, the Docker layer cache was never invalidated, causing stale Next.js builds that didn't include new dynamic routes.

Railway automatically provides `RAILWAY_GIT_COMMIT_SHA` on each deploy, which changes with every commit, ensuring a fresh Next.js build for each deployment.

Closes #248

## Test plan

- [x] Lint passes (0 errors)
- [x] Build passes with route `/api/recipes/extract-from-pdf/[jobId]` correctly included
- [x] All 1430 unit tests pass
- [ ] After merge, verify on production that `GET/DELETE /api/recipes/extract-from-pdf/:jobId` returns JSON responses instead of HTML 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)