### PR TITLE
feat: display recipes in 4-column grid on desktop

### DIFF
--- a/src/app/recipes/page.tsx
+++ b/src/app/recipes/page.tsx
@@ -35,7 +35,7 @@ export default async function RecipesPage() {
 
   return (
     <main className="min-h-screen bg-slate-950 text-slate-100">
-      <div className="mx-auto flex max-w-3xl flex-col gap-8 px-5 pb-24 pt-12 sm:px-8">
+      <div className="mx-auto flex max-w-3xl flex-col gap-8 px-5 pb-24 pt-12 sm:px-8 lg:max-w-6xl lg:px-12">
         {/* Header */}
         <header className="flex items-center justify-between">
           <p className="text-xs font-semibold uppercase tracking-[0.4em] text-emerald-400">
@@ -79,18 +79,20 @@ function RecipeListSkeleton() {
         <div className="h-10 w-36 animate-pulse rounded-xl bg-slate-800" />
       </div>
       {/* Recipe cards skeleton */}
-      {[1, 2, 3].map((i) => (
-        <div
-          key={i}
-          className="overflow-hidden rounded-xl border border-slate-800 bg-slate-900/50"
-        >
-          <div className="aspect-video animate-pulse bg-slate-800" />
-          <div className="space-y-2 p-4">
-            <div className="h-5 w-2/3 animate-pulse rounded bg-slate-800" />
-            <div className="h-4 w-full animate-pulse rounded bg-slate-800" />
+      <div className="grid gap-4 lg:grid-cols-4">
+        {[1, 2, 3, 4].map((i) => (
+          <div
+            key={i}
+            className="overflow-hidden rounded-xl border border-slate-800 bg-slate-900/50"
+          >
+            <div className="aspect-video animate-pulse bg-slate-800" />
+            <div className="space-y-2 p-4">
+              <div className="h-5 w-2/3 animate-pulse rounded bg-slate-800" />
+              <div className="h-4 w-full animate-pulse rounded bg-slate-800" />
+            </div>
           </div>
-        </div>
-      ))}
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/components/RecipeListClient.tsx
+++ b/src/components/RecipeListClient.tsx
@@ -442,7 +442,7 @@ export function RecipeListClient({
             </section>
           ) : (
             /* Recipe list */
-            <section className="grid gap-3">
+            <section className="grid gap-3 lg:grid-cols-4 lg:gap-4">
               {filteredRecipes.map((recipe) => (
                 <RecipeCard key={recipe.slug} recipe={recipe} />
               ))}
@@ -486,7 +486,7 @@ export function RecipeListClient({
             </section>
           ) : (
             /* Shared recipe list */
-            <section className="grid gap-3">
+            <section className="grid gap-3 lg:grid-cols-4 lg:gap-4">
               {filteredSharedRecipes.map((sharedRecipe) => (
                 <SharedRecipeCard
                   key={sharedRecipe.shareId}


### PR DESCRIPTION
## Summary
- Expand container width from `max-w-3xl` to `lg:max-w-6xl` for desktop viewports (≥1024px)
- Update recipe grids (My Recipes and Shared Recipes) to display 4 columns on desktop
- Update skeleton loader to show 4 cards in a grid on desktop

## Changes
| File | Change |
|------|--------|
| `src/app/recipes/page.tsx` | Container width expansion + skeleton grid |
| `src/components/RecipeListClient.tsx` | 4-column grid for recipe lists |

## Test plan
- [x] Lint passes
- [x] Build passes
- [x] All unit tests pass (1389 tests)
- [x] Desktop (≥1024px): 4-column grid displays correctly
- [x] Tablet (768px-1023px): Single-column layout preserved
- [x] Mobile (<768px): Single-column layout preserved

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)