### PR TITLE
feat: reduce desktop collection item size for higher information density

### DIFF
--- a/src/app/recipes/page.tsx
+++ b/src/app/recipes/page.tsx
@@ -79,14 +79,14 @@ function RecipeListSkeleton() {
         <div className="h-10 w-36 animate-pulse rounded-xl bg-slate-800" />
       </div>
       {/* Recipe cards skeleton */}
-      <div className="grid gap-4 lg:grid-cols-4">
-        {[1, 2, 3, 4].map((i) => (
+      <div className="grid gap-4 lg:grid-cols-6 lg:gap-3">
+        {[1, 2, 3, 4, 5, 6].map((i) => (
           <div
             key={i}
             className="overflow-hidden rounded-xl border border-slate-800 bg-slate-900/50"
           >
             <div className="aspect-video animate-pulse bg-slate-800" />
-            <div className="space-y-2 p-4">
+            <div className="space-y-2 p-4 lg:space-y-1.5 lg:p-2.5">
               <div className="h-5 w-2/3 animate-pulse rounded bg-slate-800" />
               <div className="h-4 w-full animate-pulse rounded bg-slate-800" />
             </div>

--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -113,20 +113,20 @@ export function RecipeCard({
       </div>
 
       {/* Content section */}
-      <div className="space-y-2 p-4">
+      <div className="space-y-2 p-4 lg:space-y-1.5 lg:p-2.5">
         {/* Title */}
         <h3 className="truncate font-medium text-white">{recipe.title}</h3>
 
         {/* Description */}
         {recipe.description && (
-          <p className="line-clamp-2 text-sm text-slate-400">
+          <p className="line-clamp-2 text-sm text-slate-400 lg:line-clamp-1 lg:text-xs">
             {recipe.description}
           </p>
         )}
 
         {/* Tags */}
         {visibleTags.length > 0 && (
-          <div className="flex flex-wrap gap-1.5">
+          <div className="flex flex-wrap gap-1.5 lg:gap-1">
             {visibleTags.map((tag) => {
               // Get predefined tag info for display label and color
               const predefinedTag = getTagById(tag);
@@ -136,14 +136,14 @@ export function RecipeCard({
               return (
                 <span
                   key={tag}
-                  className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs ${colorClass}`}
+                  className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs lg:px-1.5 ${colorClass}`}
                 >
                   {displayLabel}
                 </span>
               );
             })}
             {extraTagCount > 0 && (
-              <span className="inline-flex items-center rounded-full bg-slate-500/10 px-2 py-0.5 text-xs text-slate-400">
+              <span className="inline-flex items-center rounded-full bg-slate-500/10 px-2 py-0.5 text-xs text-slate-400 lg:px-1.5">
                 +{extraTagCount} more
               </span>
             )}
@@ -164,7 +164,7 @@ export function RecipeCard({
 
         {/* Time and servings */}
         {(showTimes || recipe.servings) && (
-          <div className="flex flex-wrap items-center gap-3 text-xs text-slate-500">
+          <div className="flex flex-wrap items-center gap-3 text-xs text-slate-500 lg:gap-2">
             {showTimes && <span>🕐 {timeDisplay}</span>}
             {recipe.servings && <span>👥 {servingsDisplay}</span>}
           </div>

--- a/src/components/RecipeListClient.tsx
+++ b/src/components/RecipeListClient.tsx
@@ -442,7 +442,7 @@ export function RecipeListClient({
             </section>
           ) : (
             /* Recipe list */
-            <section className="grid gap-3 lg:grid-cols-4 lg:gap-4">
+            <section className="grid gap-3 lg:grid-cols-6 lg:gap-3">
               {filteredRecipes.map((recipe) => (
                 <RecipeCard key={recipe.slug} recipe={recipe} />
               ))}
@@ -486,7 +486,7 @@ export function RecipeListClient({
             </section>
           ) : (
             /* Shared recipe list */
-            <section className="grid gap-3 lg:grid-cols-4 lg:gap-4">
+            <section className="grid gap-3 lg:grid-cols-6 lg:gap-3">
               {filteredSharedRecipes.map((sharedRecipe) => (
                 <SharedRecipeCard
                   key={sharedRecipe.shareId}

--- a/src/components/SharedRecipeCard.tsx
+++ b/src/components/SharedRecipeCard.tsx
@@ -80,30 +80,30 @@ export function SharedRecipeCard({ sharedRecipe }: SharedRecipeCardProps) {
       </div>
 
       {/* Content section */}
-      <div className="space-y-2 p-4">
+      <div className="space-y-2 p-4 lg:space-y-1.5 lg:p-2.5">
         {/* Title */}
         <h3 className="truncate font-medium text-white">{recipe.title}</h3>
 
         {/* Description */}
         {recipe.description && (
-          <p className="line-clamp-2 text-sm text-slate-400">
+          <p className="line-clamp-2 text-sm text-slate-400 lg:line-clamp-1 lg:text-xs">
             {recipe.description}
           </p>
         )}
 
         {/* Tags */}
         {recipe.tags.length > 0 && (
-          <div className="flex flex-wrap gap-1.5">
+          <div className="flex flex-wrap gap-1.5 lg:gap-1">
             {recipe.tags.slice(0, 3).map((tag) => (
               <span
                 key={tag}
-                className="inline-flex items-center rounded-full bg-slate-500/10 px-2 py-0.5 text-xs text-slate-400"
+                className="inline-flex items-center rounded-full bg-slate-500/10 px-2 py-0.5 text-xs text-slate-400 lg:px-1.5"
               >
                 {tag}
               </span>
             ))}
             {recipe.tags.length > 3 && (
-              <span className="inline-flex items-center rounded-full bg-slate-500/10 px-2 py-0.5 text-xs text-slate-400">
+              <span className="inline-flex items-center rounded-full bg-slate-500/10 px-2 py-0.5 text-xs text-slate-400 lg:px-1.5">
                 +{recipe.tags.length - 3} more
               </span>
             )}
@@ -112,7 +112,7 @@ export function SharedRecipeCard({ sharedRecipe }: SharedRecipeCardProps) {
 
         {/* Time and servings */}
         {(showTimes || recipe.servings) && (
-          <div className="flex flex-wrap items-center gap-3 text-xs text-slate-500">
+          <div className="flex flex-wrap items-center gap-3 text-xs text-slate-500 lg:gap-2">
             {showTimes && <span>🕐 {timeDisplay}</span>}
             {recipe.servings && <span>👥 {servingsDisplay}</span>}
           </div>


### PR DESCRIPTION
## Summary
- Increase grid columns from 4 to 6 on desktop (≥1024px) for ~50% smaller card area
- Reduce card padding (p-4 → p-2.5) and spacing (space-y-2 → space-y-1.5) on desktop
- Description text truncated to 1 line on desktop (2 lines on mobile)
- Tag and metadata spacing tightened on desktop
- Mobile layout completely unchanged

## Files Changed
- `src/components/RecipeListClient.tsx` - Grid: 4→6 columns, gap-4→gap-3
- `src/components/RecipeCard.tsx` - Responsive padding and spacing
- `src/components/SharedRecipeCard.tsx` - Matching responsive styling
- `src/app/recipes/page.tsx` - Skeleton loader updated to 6 cards

## Test plan
- [x] Lint passes
- [x] Build succeeds
- [x] Unit tests pass (1389 tests)
- [x] Desktop viewport (1280px): 6 cards per row, compact styling
- [x] Mobile viewport (375px): Single column, unchanged styling
- [ ] CI checks pass

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)