### PR TITLE
feat: increase font size in workout player by 50%

### DIFF
--- a/src/components/GuidedRoutinePlayer.tsx
+++ b/src/components/GuidedRoutinePlayer.tsx
@@ -460,11 +460,11 @@ export function GuidedRoutinePlayer({
               />
             )}
             <div className="flex-1 space-y-3">
-              <h1 className="text-3xl font-semibold leading-tight sm:text-4xl">
+              <h1 className="text-5xl font-semibold leading-tight sm:text-6xl">
                 {hasFinished ? t("workoutComplete") : currentSegment?.title}
               </h1>
               {!hasFinished && currentSegment?.detail ? (
-                <p className="text-xl text-slate-200 sm:text-2xl">
+                <p className="text-3xl text-slate-200 sm:text-4xl">
                   {currentSegment.detail}
                 </p>
               ) : null}


### PR DESCRIPTION
## Summary
- Increase exercise title font size by ~50-60% for better readability during workouts
- Increase exercise detail/instructions font size by 50%
- Timer display remains prominent and readable
- UI remains visually balanced on mobile devices

**Changes:**
- Title: `text-3xl` → `text-5xl` (mobile), `text-4xl` → `text-6xl` (desktop)
- Detail: `text-xl` → `text-3xl` (mobile), `text-2xl` → `text-4xl` (desktop)

Closes #318

## Test plan
- [x] Lint passes
- [x] Build succeeds  
- [x] All unit tests pass (1400 tests)
- [x] Manual testing on desktop viewport
- [x] Manual testing on mobile viewport (390x844)
- [x] UI visually balanced with exercise images

🤖 Generated with [Claude Code](https://claude.com/claude-code)