### PR TITLE
fix: prevent chat modal scroll-through on mobile

### DIFF
--- a/src/components/ChatModal.tsx
+++ b/src/components/ChatModal.tsx
@@ -774,7 +774,7 @@ export function ChatModal({
           </div>
         </div>
 
-        <div className="flex-1 overflow-y-auto p-4 space-y-4 scrollbar-hide" style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}>
+        <div className="flex-1 overflow-y-auto p-4 space-y-4 scrollbar-hide" style={{ scrollbarWidth: 'none', msOverflowStyle: 'none', touchAction: 'pan-y', overscrollBehavior: 'contain' }}>
           {messages.length === 0 && !streamingContent && (
             <div className="text-center text-slate-400 py-8">
               <p className="mb-2">{t('aiAssistantDescription')}</p>


### PR DESCRIPTION
## Summary
- Add `touch-action: pan-y` CSS property to chat messages container to ensure touch gestures only scroll chat content vertically
- Add `overscroll-behavior: contain` CSS property to prevent scroll events from propagating to the underlying page when reaching scroll boundaries

Closes #320

## Test plan
- [ ] Open chat modal on mobile device
- [ ] Scroll chat content up and down
- [ ] Verify underlying page does not scroll
- [ ] Test at scroll boundaries (top and bottom of chat)
- [ ] Verify scroll works normally on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)