### PR TITLE
fix: update screenshot capture warning to reference correct library

### DIFF
--- a/src/components/ChatModal.tsx
+++ b/src/components/ChatModal.tsx
@@ -287,7 +287,7 @@ export function ChatModal({
       console.log('[Feedback Screenshots] Captured', screenshots.length, 'screenshots');
 
       if (screenshots.length === 0) {
-        console.warn('[Feedback Screenshots] No screenshots captured - html2canvas may have failed');
+        console.warn('[Feedback Screenshots] No screenshots captured - screenshot capture may have failed');
         return;
       }
 


### PR DESCRIPTION
## Summary
- Updated warning message in `ChatModal.tsx` to be library-agnostic
- Changed from "html2canvas may have failed" to "screenshot capture may have failed"
- This is a cosmetic fix for development logging after PR #344 migrated from html2canvas to modern-screenshot

Closes #347

## Test plan
- [x] Lint passes
- [x] Build passes  
- [x] Unit tests pass (1452 tests)
- [x] Manual verification - chat modal opens and works correctly

**Note:** No new unit tests added as this is a cosmetic change to a console.warn message string. The screenshot capture functionality is already covered by existing tests in `src/lib/__tests__/screenshot-capture.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)